### PR TITLE
Fix comment hourly limit

### DIFF
--- a/app/controllers/CommentController.php
+++ b/app/controllers/CommentController.php
@@ -45,7 +45,7 @@ class CommentController extends ApplicationController
 
     public function create()
     {
-         if (current_user()->is_member_or_lower() && $this->params()->commit == "Post" && Comment::where("user_id = ? AND created_at > ?", current_user()->id, strtotime('-1 hour'))->count() >= CONFIG()->member_comment_limit) {
+         if (current_user()->is_member_or_lower() && $this->params()->commit == "Post" && Comment::where("user_id = ? AND created_at > SUBDATE(NOW(), INTERVAL 1 HOUR)", current_user()->id)->count() >= CONFIG()->member_comment_limit) {
             # TODO: move this to the model
             $this->respond_to_error("Hourly limit exceeded", '#index', array('status' => 421));
             return;

--- a/app/helpers/HistoryHelper.php
+++ b/app/helpers/HistoryHelper.php
@@ -191,7 +191,7 @@ class HistoryHelper extends Rails\ActionView\Helper
 
         if (empty($options['show_name']) && $history->group_by_table == 'tags') {
             $tag = $history->history_changes[0]->obj();
-            $html .= $this->tag_link($tag->name);
+            $html .= $this->tag_link($this->h($tag->name));
             $html .= ': ';
         }
 

--- a/app/models/Tag.php
+++ b/app/models/Tag.php
@@ -31,8 +31,8 @@ class Tag extends Rails\ActiveRecord\Base
         // replace all sequences of Unicode separators (including space) with underscore
         $tn = preg_replace('/\p{Z}+/', '_', $tn);
 
-        // strip control characters, leading/trailing underscore and search operator conflicts
-        $tn = preg_replace('/([\p{C}\*\`]|^[\~\-\_]+|[\_]+$)+/', '', $tn);
+        // strip control characters, extraneous underscores, and search operator conflicts
+        $tn = preg_replace('/([\p{C}\*\`]+|(?<=\_)\_+|^[\~\-\_]+|[\_]+$)/', '', $tn);
 
         // convert everything that remains to lower case
         $tn = strtolower($tn);

--- a/app/models/Tag.php
+++ b/app/models/Tag.php
@@ -146,6 +146,9 @@ class Tag extends Rails\ActiveRecord\Base
         if (preg_match('/^(.+?)\.\.(.+)/', $range, $m))
             return array('between', self::parse_cast($m[1], $type), self::parse_cast($m[2], $type));
 
+        elseif (preg_match('/^=(.+)|^\.\.(.+)/', $range, $m))
+            return array('eq', self::parse_cast($m[1], $type));
+
         elseif (preg_match('/^<=(.+)|^\.\.(.+)/', $range, $m))
             return array('lte', self::parse_cast($m[1], $type));
 

--- a/app/models/Tag.php
+++ b/app/models/Tag.php
@@ -17,7 +17,50 @@ class Tag extends Rails\ActiveRecord\Base
             ])
             ->versioning_group_by(['action' => 'edit']);
     }
-    
+
+
+
+    /**
+     * Normalize a tag name to conform with tag naming rules.
+     *
+     * \param tn    The tag name to be normalized
+     * \returns     The normalized tag name
+     */
+    static public function normalize_tag_name($tn)
+    {
+        // replace all sequences of Unicode separators (including space) with underscore
+        $tn = preg_replace('/\p{Z}+/', '_', $tn);
+
+        // strip control characters, leading/trailing underscore and search operator conflicts
+        $tn = preg_replace('/([\p{C}\*\`]|^[\~\-\_]+|[\_]+$)+/', '', $tn);
+
+        // convert everything that remains to lower case
+        $tn = strtolower($tn);
+
+        return $tn;
+    }
+
+
+
+    /**
+     * Normalize and validate a (non-meta) tag name.
+     *
+     * \param tn    The tag name to validate
+     * \returns     The normalized tag when it is valid, otherwise false.
+     */
+    static public function validate_tag_name($tn)
+    {
+        $tn = Tag::normalize_tag_name($tn);
+
+        // check for empty tag and conflicts with meta tags
+        return !($tn == '' || preg_match(
+            '/^(unlocked|deleted|ext|user|sub|vote|fav|md5|rating|width|height|mpixels|score' .
+            '|source|id|date|pool|parent|order|change|holds|pending|shown|limit)\:/', $tn))
+            ? $tn : false;
+    }
+
+
+
     static public function find_or_create_by_name($name)
     {
         # Reserve ` as a field separator for tag/summary.

--- a/app/models/TagImplication.php
+++ b/app/models/TagImplication.php
@@ -1,6 +1,13 @@
 <?php
 class TagImplication extends Rails\ActiveRecord\Base
 {
+    private $predicate = '';    // input predicate string
+    private $consequent = '';   // input consequent string
+    private $predtag = null;    // memoized predicate tag
+    private $constag = null;    // memoized consequent tag
+
+
+
     static public function with_implied($tags)
     {
         if (!$tags)
@@ -44,29 +51,39 @@ class TagImplication extends Rails\ActiveRecord\Base
         
         $this->destroy();
     }
-    
+
+
+
     public function setPredicate($name)
     {
-        $t = Tag::find_or_create_by_name($name);
-        $this->predicate_id = $t->id;
+        $this->predicate = $name;
     }
-    
+
+
+
     public function getPredicate()
     {
-        return Tag::find($this->predicate_id);
+        return $this->predtag != null ? $this->predtag
+            : ($this->predtag = Tag::find($this->predicate_id));
     }
-    
+
+
+
     public function setConsequent($name)
     {
-        $t = Tag::find_or_create_by_name($name);
-        $this->consequent_id = $t->id;
+        $this->consequent = $name;
     }
-    
+
+
+
     public function getConsequent()
     {
-        return Tag::find($this->consequent_id);
+        return $this->constag != null ? $this->constag
+            : ($this->constag = Tag::find($this->consequent_id));
     }
-    
+
+
+
     public function approve($user_id, $ip_addr)
     {
         self::connection()->executeSql("UPDATE tag_implications SET is_pending = FALSE WHERE id = " . $this->id);
@@ -92,10 +109,34 @@ class TagImplication extends Rails\ActiveRecord\Base
     protected function callbacks()
     {
         return array(
-            'before_create' => array('validate_uniqueness')
+            'before_create' => array('validate_input', 'prepare_create', 'validate_uniqueness')
         );
     }
-    
+
+
+
+    protected function validate_input()
+    {
+        $this->predicate = Tag::validate_tag_name($this->predicate);
+        $this->consequent = Tag::validate_tag_name($this->consequent);
+
+        $err = $this->errors();
+        if (!$this->predicate) { $err->add('predicate', 'invalid or empty'); return false; }
+        if (!$this->consequent) { $err->add('consequent', 'invalid or empty'); return false; }
+    }
+
+
+
+    protected function prepare_create()
+    {
+        $this->predtag = Tag::find_or_create_by_name($this->predicate);
+        $this->constag = Tag::find_or_create_by_name($this->consequent);
+        $this->predicate_id = $this->predtag->id;
+        $this->consequent_id = $this->constag->id;
+    }
+
+
+
     protected function validate_uniqueness()
     {
         // $this->predicate_is($this->new_predicate);

--- a/app/models/TagImplication.php
+++ b/app/models/TagImplication.php
@@ -129,8 +129,16 @@ class TagImplication extends Rails\ActiveRecord\Base
 
     protected function prepare_create()
     {
-        $this->predtag = Tag::find_or_create_by_name($this->predicate);
-        $this->constag = Tag::find_or_create_by_name($this->consequent);
+        if (!($this->predtag = Tag::find_or_create_by_name($this->predicate))) {
+            $this->errors()->addToBase("Failed to create tag {$this->predicate}");
+            return false;
+        }
+
+        if (!($this->constag = Tag::find_or_create_by_name($this->consequent))) {
+            $this->errors()->addToBase("Failed to create tag {$this->consequent}");
+            return false;
+        }
+
         $this->predicate_id = $this->predtag->id;
         $this->consequent_id = $this->constag->id;
     }

--- a/db/migrate/20210905133001_change_tag_length.php
+++ b/db/migrate/20210905133001_change_tag_length.php
@@ -1,0 +1,8 @@
+<?php
+class ChangeTagLength extends Rails\ActiveRecord\Migration\Base
+{
+    public function up()
+    {
+        $this->execute("ALTER TABLE `tags` CHANGE `name` `name` varchar(255) NOT NULL");
+    }
+}


### PR DESCRIPTION
Fix the hourly limit for commenting and merge Zolxys' fixes.

I am not sure exactly why the old code did not work as I do not fully understand how Rails passes datetime parameters to SQL but I fixed this by changing the query to have SQL do the datetime calculation instead of doing it in PHP, which is better anyway.

Also, FYI. The MyImouto code does not normalize datetimes to UTC before storing into the database, which is just bad design. So... if you ever change the server timezone, it will likely cause many issues with dates and times.

