### PR TITLE
Fix a security issue and the very long search query bug

### DIFF
--- a/app/controllers/UserController.php
+++ b/app/controllers/UserController.php
@@ -246,14 +246,15 @@ class UserController extends ApplicationController
 
         // filter attributes to only what that the user is actually allowed to change here
         // email and password should not be allowed here as password verification is required
-        $user = array_intersect_key($this->params()->user, [
+        $user = array_intersect_key($this->params()->user, array_fill_keys([
             'blacklisted_tags',
             'my_tags',
             'always_resize_images',
             'receive_dmails',
             'show_samples',
             'use_browser',
-            'show_advanced_editing']);
+            'pool_browse_mode',
+            'show_advanced_editing'], null));
 
         if (current_user()->updateAttributes($user)) {
             $this->respond_to_success("Account settings saved", '#edit');

--- a/app/controllers/UserController.php
+++ b/app/controllers/UserController.php
@@ -244,7 +244,18 @@ class UserController extends ApplicationController
             return;
         }
 
-        if (current_user()->updateAttributes($this->params()->user)) {
+        // filter attributes to only what that the user is actually allowed to change here
+        // email and password should not be allowed here as password verification is required
+        $user = array_intersect_key($this->params()->user, [
+            'blacklisted_tags',
+            'my_tags',
+            'always_resize_images',
+            'receive_dmails',
+            'show_samples',
+            'use_browser',
+            'show_advanced_editing']);
+
+        if (current_user()->updateAttributes($user)) {
             $this->respond_to_success("Account settings saved", '#edit');
         } else {
             if ($this->params()->render and $this->params()->render['view']) {

--- a/app/models/Pool.php
+++ b/app/models/Pool.php
@@ -235,7 +235,7 @@ class Pool extends Rails\ActiveRecord\Base
     
     public function get_zip_filename(array $options = [])
     {
-        $filename = str_replace('?', "", $this->pretty_name());
+        $filename = str_replace(['?', '/'], ['', ''], $this->pretty_name());
         if (!empty($options['jpeg']))
             $filename .= " (JPG)";
         return $filename . ".zip";

--- a/app/models/Post/CountMethods.php
+++ b/app/models/Post/CountMethods.php
@@ -6,7 +6,7 @@ trait PostCountMethods
         # A small sanitation
         $tags = preg_replace('/ +/', ' ', trim($tags));
         $cache_version = (int)Rails::cache()->read('$cache_version');
-        $key = ['post_count' => $tags, 'v' => $cache_version];
+        $key = ['post_count' => hash('sha256', $tags, false), 'v' => $cache_version];
 
         $count = (int)Rails::cache()->fetch($key, function() use ($tags) {
             list($sql, $params) = Post::generate_sql($tags, ['count' => true]);

--- a/app/models/Tag.php
+++ b/app/models/Tag.php
@@ -499,7 +499,7 @@ class Tag extends Rails\ActiveRecord\Base
         
         !is_array($tags) && $tags = array($tags);
         
-        return Rails::cache()->fetch(['category' => 'reltags', 'tags' => implode(',', $tags)], ['expires_in' => '1 hour'], function() use ($tags) {
+        return Rails::cache()->fetch(['category' => 'reltags', 'tags' => hash('sha256', implode(',', $tags), false)], ['expires_in' => '1 hour'], function() use ($tags) {
             $from = array("posts_tags pt0");
             $cond = array("pt0.post_id = pt1.post_id");
             $sql = "SELECT ";

--- a/app/views/user/home.php
+++ b/app/views/user/home.php
@@ -13,7 +13,7 @@
       <li><?= $this->linkTo($this->t('.reset_password'), ['action' => 'reset_password']) ?></li>
     </ul>
   <?php else: ?>
-    <h2><?= $this->t(['.greet_user', 'u' => $this->h(current_user()->name])) ?></h2>
+    <h2><?= $this->t(['.greet_user', 'u' => $this->h(current_user()->name)]) ?></h2>
     <p><?= $this->t('.action_info') ?></p>
 
     <div class="section">


### PR DESCRIPTION
This hashes the search tag list in the file cache to allow search queries longer than the filename limit.

This also fixes a security issue in that there is no filter of what the user can change about their account on user/update so it is possible to craft an HTTP request to change account attributes that one should not be allowed to change. In particular, it is possible for a user to change their name while also bypassing validation.

I can't be sure, but I think the user with id 94758 may have exploited this to put actual spaces in their name which is not supposed to be allowed. The spaces screw things up. I don't know if there are others that have done this.