### PR TITLE
Fix a couple XSS issues

### DIFF
--- a/app/helpers/HistoryHelper.php
+++ b/app/helpers/HistoryHelper.php
@@ -191,7 +191,7 @@ class HistoryHelper extends Rails\ActionView\Helper
 
         if (empty($options['show_name']) && $history->group_by_table == 'tags') {
             $tag = $history->history_changes[0]->obj();
-            $html .= $this->tag_link($this->h($tag->name));
+            $html .= $this->tag_link($tag->name);
             $html .= ': ';
         }
 

--- a/app/helpers/PostHelper.php
+++ b/app/helpers/PostHelper.php
@@ -28,7 +28,7 @@ class PostHelper extends Rails\ActionView\Helper
         
         $image_id = isset($options['image_id']) ? 'id="'.$options['image_id'].'"' : null;
         
-        $image_title = $is_post ? $this->h("Rating: ".$post->pretty_rating()." Score: ".$post->score." Tags: ".$this->h($post->cached_tags." User: ".$post->author())) : null;
+        $image_title = $is_post ? "Rating: ".$post->pretty_rating()." Score: ".$post->score." Tags: ".$this->h($post->cached_tags)." User: ".$this->h($post->author()) : null;
         
         $link_onclick = isset($options['onclick']) ? 'onclick="'.$options['onclick'].'"' : null;
         

--- a/app/helpers/TagHelper.php
+++ b/app/helpers/TagHelper.php
@@ -107,7 +107,7 @@ class TagHelper extends Rails\ActionView\Helper
             } else
                 $mouseover = $mouseout = '';
             
-            $html .= '<a href="/post?tags=' . $this->u($name) . '"' . $mouseover . $mouseout . '>' . (str_replace("_", " ", $name)) . '</a> ';
+            $html .= '<a href="/post?tags=' . $this->u($name) . '"' . $mouseover . $mouseout . '>' . $this->h(str_replace("_", " ", $name)) . '</a> ';
             $html .= '<span class="post-count">' . $count . '</span> ';
             $html .= '</li>';
         }

--- a/app/helpers/TagHelper.php
+++ b/app/helpers/TagHelper.php
@@ -12,7 +12,7 @@ class TagHelper extends Rails\ActionView\Helper
         $html = !$prefix ? '' : $this->contentTag('span', $prefix, array('class' => $obsolete_tag));
         $html .= $this->contentTag(
                                     'span',
-                                    $this->linkTo($name, array('post#index', 'tags' => $name)),
+                                    $this->linkTo($this->h($name), array('post#index', 'tags' => $name)),
                                     array('class' => "tag-type-".$tag_type.$obsolete_tag)
                                   );
         return $html;


### PR DESCRIPTION
Fix a couple more XSS vulnerabilities. Also fix a bug I just noticed with a previous change to HistoryHelper by moving the escape into the TagHelper instead.

If you want to test for basic XSS vulnerabilities you can put this in input fields including as a post tags. If your browser displays a message box with "XSS" in it then the code was executed and there is a vulnerability somewhere.
`<script>alert('XSS')</script>`