### PR TITLE
Database Migrations / Charset Issue

### DIFF
--- a/config/FixHistory.php
+++ b/config/FixHistory.php
@@ -112,7 +112,7 @@ for ($pid = 0; $pid <= $pmax; ++$pid) {
         $hid = reset($changes)->history_id;
         
         if (!$hid) {
-            $hinsert->bind_param('ii', $uid, $pid);
+            $hinsert->bind_param('ii', $user->id, $pid);
             $hinsert->execute();
             $hid = $sql->insert_id;
         }

--- a/config/FixHistory.php
+++ b/config/FixHistory.php
@@ -109,7 +109,7 @@ for ($pid = 0; $pid <= $pmax; ++$pid) {
         }
 
         $lcnt = 0;
-        $hid = reset($changes)->history_id;
+        $hid = count($changes) == 0 ? null : reset($changes)->history_id;
         
         if (!$hid) {
             $hinsert->bind_param('ii', $user->id, $pid);

--- a/config/FixHistory.php
+++ b/config/FixHistory.php
@@ -33,16 +33,33 @@ $dbconfig = $dbconfig[$input];
 
 print("\nConnecting to SQL server {$dbconfig['host']}...\n");
 mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+set_error_handler(function($errno, $errstr, $errfile, $errline ){
+    throw new ErrorException($errstr, $errno, 0, $errfile, $errline);
+});
+
 $sql = new mysqli($dbconfig['host'], $dbconfig['username'], $dbconfig['password'], $dbconfig['database']);
 
 
 $pid = 0; $ccnt = 0; $pcnt = 0;
+
+$user = $sql->query(
+    "SELECT `id`, `name` FROM `users`"
+        . " WHERE `level` >= 50"
+        . " ORDER BY `id` ASC"
+        . " LIMIT 1")->fetch_object();
+
+if (!$user) { die("no suitable user account found"); }
+
 $pmax = $sql->query("SELECT MAX(`id`) FROM `posts`")->fetch_row()[0];
-print("\nProcessing post history...");
+
+print("\nHistory will be attributed to user {$user->id} ({$user->name}).");
+print("\nA total of {$pmax} posts will be processed.\n");
+$continue = readline("Continue (y or n): ");
+if (strtolower(trim($continue)) != 'y') { print("Aborting.\n"); exit(0); }
 
 
 $attrs = [
-    'cached_tags' => null,
     'source' => '',
     'rating' => null,
     'parent_id' => null];
@@ -58,7 +75,7 @@ $cselect = $sql->prepare(
 $hinsert = $sql->prepare(
     "INSERT INTO `histories`"
         . "(`created_at`, `user_id`, `group_by_id`, `group_by_table`, `aux_as_json`)"
-        . "VALUES (NOW(), 1, ?, 'posts', NULL)");
+        . "VALUES (NOW(), ?, ?, 'posts', NULL)");
 
 $cinsert = $sql->prepare(
     "INSERT INTO `history_changes`"
@@ -70,7 +87,9 @@ for ($pid = 0; $pid <= $pmax; ++$pid) {
 
     if ($pid % 10 == 0) { // report progress and yield to more important processes
         printf("\rProcessing post history... %5.1f%% (%u/%u)", 100.0*$pid/$pmax, $pid, $pmax);
-        usleep(1000);
+        // only yield; if script causes performance issues, comment out sleep and uncomment usleep below
+        sleep(0);
+        //usleep(1000);
     }
 
     $sql->begin_transaction();
@@ -93,7 +112,7 @@ for ($pid = 0; $pid <= $pmax; ++$pid) {
         $hid = reset($changes)->history_id;
         
         if (!$hid) {
-            $hinsert->bind_param('i', $pid);
+            $hinsert->bind_param('ii', $uid, $pid);
             $hinsert->execute();
             $hid = $sql->insert_id;
         }
@@ -111,7 +130,9 @@ for ($pid = 0; $pid <= $pmax; ++$pid) {
         $sql->commit();
     } catch(Exception $ex) {
         $sql->rollback();
-        throw $ex;
+        $msg = $ex->getMessage();
+        print("An error occurred proccesing post #{$pid}:\n{$msg}\n");
+        exit(1);
     }
 }
 

--- a/db/migrate/20211002000001_add_missing_constraints.php
+++ b/db/migrate/20211002000001_add_missing_constraints.php
@@ -6,21 +6,21 @@ class AddMissingConstraints extends Rails\ActiveRecord\Migration\Base
     public function up()
     {
         // add missing foreign key constraints
-        $this->createForeignKey('favorites', 'post_id', 'posts', 'id', ['delete' => 'cascade']);
-        $this->createForeignKey('favorites', 'user_id', 'users', 'id');
-        $this->createForeignKey('histories', 'user_id', 'users', 'id');
-        $this->createForeignKey('note_versions', 'user_id', 'users', 'id');
-        $this->createForeignKey('notes', 'user_id', 'users', 'id');
-        $this->createForeignKey('pools', 'user_id', 'users', 'id');
-        $this->createForeignKey('post_tag_histories', 'user_id', 'users', 'id');
-        $this->createForeignKey('wiki_page_versions', 'user_id', 'users', 'id');
+        $this->createForeignKey('Favorite', 'favorites', 'post_id', 'posts', 'id', ['delete' => 'cascade']);
+        $this->createForeignKey('Favorite', 'favorites', 'user_id', 'users', 'id');
+        $this->createForeignKey('History', 'histories', 'user_id', 'users', 'id');
+        $this->createForeignKey('NoteVersion', 'note_versions', 'user_id', 'users', 'id');
+        $this->createForeignKey('Note', 'notes', 'user_id', 'users', 'id');
+        $this->createForeignKey('Pool', 'pools', 'user_id', 'users', 'id');
+        $this->createForeignKey('PostTagHistory', 'post_tag_histories', 'user_id', 'users', 'id');
+        $this->createForeignKey('WikiPageVersion', 'wiki_page_versions', 'user_id', 'users', 'id');
 
         // there is a duplicate foreign key on tag_implications.consequent_id so remove the duplicate
         $this->dropForeignKey('tag_implications', 'fk_consequent_id');
 
         // add missing unique key constraints
-        $this->createUniqueKey('artists', 'name');
-        $this->createUniqueKey('wiki_pages', 'title');
+        $this->createUniqueKey('Artist', 'artists', 'name');
+        $this->createUniqueKey('WikiPage', 'wiki_pages', 'title');
 
         // add some more indexes to help improve performance
         $this->createIndex('histories', ['group_by_id', 'group_by_table']); // improves object specific history performance
@@ -40,6 +40,33 @@ class AddMissingConstraints extends Rails\ActiveRecord\Migration\Base
     }
 
 
+    private function checkUniqueKeyConflicts($model, $table, $attr)
+    {
+        $conflicts = 0;
+        $sql = "SELECT * FROM `{$table}` GROUP BY `{$attr}` HAVING COUNT(`{$attr}`) > 1";
+        $collection = call_user_func([$model, 'findBySql'], $sql);
+        foreach ($collection as $obj) { ++$conflicts; }
+        if ($conflicts > 0) { throw new \Exception(
+            "Cannot create unique key for {$table}.{$attr};"
+            . " {$conflicts} set" . ($conflicts>1?'s':'') . " of duplicates exists"); }
+    }
+
+
+
+    private function checkForeignKeyConflicts($model, $table, $column, $reftable, $refcolumn)
+    {
+        $conflicts = 0;
+        $sql = "SELECT `{$table}`.* FROM `{$table}` LEFT JOIN `{$reftable}`"
+            . " ON `{$table}`.`{$column}` = `{$reftable}`.`${refcolumn}`"
+            . " WHERE `{$reftable}`.`{$refcolumn}` IS NULL";
+        $collection = call_user_func([$model, 'findBySql'], $sql);
+        foreach ($collection as $obj) { ++$conflicts; }
+        if ($conflicts > 0) { throw new \Exception(
+            "Cannot create foreign key for {$table}.{$column} => {$reftable}.{$refcolumn};"
+            . " {$conflicts} rows exists in the left table that reference non-existant rows in the right table"); }
+    }
+
+
 
     private function dropForeignKey($table, $name)
     {
@@ -50,8 +77,9 @@ class AddMissingConstraints extends Rails\ActiveRecord\Migration\Base
 
 
 
-    private function createUniqueKey($table, $column)
+    private function createUniqueKey($model, $table, $column)
     {
+        $this->checkUniqueKeyConflicts($model, $table, $column);
         $name = 'uk_' . $table . '__' . $column;
         $this->execute("IF NOT EXISTS (SELECT 1 FROM `information_schema`.`TABLE_CONSTRAINTS`"
             . " WHERE `CONSTRAINT_SCHEMA`=DATABASE() AND `TABLE_NAME`='{$table}' AND `CONSTRAINT_NAME`='{$name}')"
@@ -59,8 +87,9 @@ class AddMissingConstraints extends Rails\ActiveRecord\Migration\Base
     }
 
 
-    private function createForeignKey($table, $column, $reftable, $refcolumn, $options = [])
+    private function createForeignKey($model, $table, $column, $reftable, $refcolumn, $options = [])
     {
+        $this->checkForeignKeyConflicts($model, $table, $column, $reftable, $refcolumn);
         $name = 'fk_' . $table . '__' . $column;
         $this->execute("IF NOT EXISTS (SELECT 1 FROM `information_schema`.`TABLE_CONSTRAINTS`"
             . " WHERE `CONSTRAINT_SCHEMA`=DATABASE() AND `TABLE_NAME`='{$table}' AND `CONSTRAINT_NAME`='{$name}')"

--- a/db/migrate/20211002000001_add_missing_constraints.php
+++ b/db/migrate/20211002000001_add_missing_constraints.php
@@ -1,0 +1,84 @@
+<?php
+class AddMissingConstraints extends Rails\ActiveRecord\Migration\Base
+{
+
+
+    public function up()
+    {
+        // add missing foreign key constraints
+        $this->createForeignKey('favorites', 'post_id', 'posts', 'id', ['delete' => 'cascade']);
+        $this->createForeignKey('favorites', 'user_id', 'users', 'id');
+        $this->createForeignKey('histories', 'user_id', 'users', 'id');
+        $this->createForeignKey('note_versions', 'user_id', 'users', 'id');
+        $this->createForeignKey('notes', 'user_id', 'users', 'id');
+        $this->createForeignKey('pools', 'user_id', 'users', 'id');
+        $this->createForeignKey('post_tag_histories', 'user_id', 'users', 'id');
+        $this->createForeignKey('wiki_page_versions', 'user_id', 'users', 'id');
+
+        // there is a duplicate foreign key on tag_implications.consequent_id so remove the duplicate
+        $this->dropForeignKey('tag_implications', 'fk_consequent_id');
+
+        // add missing unique key constraints
+        $this->createUniqueKey('artists', 'name');
+        $this->createUniqueKey('wiki_pages', 'title');
+
+        // add some more indexes to help improve performance
+        $this->createIndex('histories', ['group_by_id', 'group_by_table']); // improves object specific history performance
+        $this->createIndex('history_changes', ['remote_id', 'table_name']); // improves object specific history performance
+        $this->createIndex('ip_bans', ['ip_addr']);     // improves ip ban lookup perfomance
+        $this->createIndex('posts', ['source']);        // improves "source:" metatag search performance
+        $this->createIndex('posts', ['width']);         // improves "width:" metatag search performance
+        $this->createIndex('posts', ['height']);        // improves "height:" metatag search performance
+        $this->createIndex('posts', ['score']);         // improves "score:" metatag search performance
+        
+        // Additionally tag_subscriptions should have a unique key on (user_id, name)
+        // but I wont worry about that now since we may scrap this later
+
+        // Additionally some tables (user_blacklisted_tags for example) have unique keys
+        // that should really be primary keys but fixing this is not very practical now.
+
+    }
+
+
+
+    private function dropForeignKey($table, $name)
+    {
+        $this->execute("IF EXISTS (SELECT 1 FROM `information_schema`.`TABLE_CONSTRAINTS`"
+            . " WHERE `CONSTRAINT_SCHEMA`=DATABASE() AND `TABLE_NAME`='{$table}' AND `CONSTRAINT_NAME`='{$name}')"
+            . " THEN ALTER TABLE `{$table}` DROP CONSTRAINT `{$name}`; END IF;");        
+    }
+
+
+
+    private function createUniqueKey($table, $column)
+    {
+        $name = 'uk_' . $table . '__' . $column;
+        $this->execute("IF NOT EXISTS (SELECT 1 FROM `information_schema`.`TABLE_CONSTRAINTS`"
+            . " WHERE `CONSTRAINT_SCHEMA`=DATABASE() AND `TABLE_NAME`='{$table}' AND `CONSTRAINT_NAME`='{$name}')"
+            . " THEN ALTER TABLE `{$table}` ADD CONSTRAINT `{$name}` UNIQUE(`${column}`); END IF;");
+    }
+
+
+    private function createForeignKey($table, $column, $reftable, $refcolumn, $options = [])
+    {
+        $name = 'fk_' . $table . '__' . $column;
+        $this->execute("IF NOT EXISTS (SELECT 1 FROM `information_schema`.`TABLE_CONSTRAINTS`"
+            . " WHERE `CONSTRAINT_SCHEMA`=DATABASE() AND `TABLE_NAME`='{$table}' AND `CONSTRAINT_NAME`='{$name}')"
+            . " THEN ALTER TABLE `{$table}` ADD CONSTRAINT `{$name}`"
+            . " FOREIGN KEY (`${column}`) REFERENCES `{$reftable}` (`{$refcolumn}`)"
+            . (isset($options['delete']) ? " ON DELETE {$options['delete']}" : "")
+            . (isset($options['update']) ? " ON UPDATE {$options['update']}" : "")
+            . "; END IF;");
+    }
+
+
+    private function createIndex($table, $columns)
+    {
+        $name = 'ix_' . $table . '__' . implode('__', $columns);
+        $colspec = implode(',', array_map(function($c) { return "`{$c}`"; }, $columns));
+        $this->execute("IF NOT EXISTS (SELECT 1 FROM `information_schema`.`STATISTICS`"
+            . " WHERE `TABLE_SCHEMA`=DATABASE() AND `TABLE_NAME`='{$table}' AND `INDEX_NAME`='{$name}')"
+            . " THEN ALTER TABLE `{$table}` ADD INDEX `{$name}` ({$colspec}); END IF;");
+    }
+
+}

--- a/db/migrate/20211002000002_set_charset_utf8mb4.php
+++ b/db/migrate/20211002000002_set_charset_utf8mb4.php
@@ -1,0 +1,43 @@
+<?php
+class SetCharsetUtf8mb4 extends Rails\ActiveRecord\Migration\Base
+{
+    public function up()
+    {
+        $this->execute("ALTER TABLE `advertisements`        CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+        $this->execute("ALTER TABLE `artists`               CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+        $this->execute("ALTER TABLE `artists_urls`          CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+        $this->execute("ALTER TABLE `bans`                  CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+        $this->execute("ALTER TABLE `batch_uploads`         CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+        $this->execute("ALTER TABLE `comments`              CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+        $this->execute("ALTER TABLE `dmails`                CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+        $this->execute("ALTER TABLE `favorites`             CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+        $this->execute("ALTER TABLE `flagged_post_details`  CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+        $this->execute("ALTER TABLE `forum_posts`           CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+        $this->execute("ALTER TABLE `histories`             CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+        $this->execute("ALTER TABLE `history_changes`       CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+        $this->execute("ALTER TABLE `inline_images`         CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+        $this->execute("ALTER TABLE `inlines`               CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+        $this->execute("ALTER TABLE `ip_bans`               CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+        $this->execute("ALTER TABLE `job_tasks`             CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+        $this->execute("ALTER TABLE `note_versions`         CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+        $this->execute("ALTER TABLE `notes`                 CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+        $this->execute("ALTER TABLE `pools`                 CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+        $this->execute("ALTER TABLE `pools_posts`           CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+        $this->execute("ALTER TABLE `post_tag_histories`    CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+        $this->execute("ALTER TABLE `post_votes`            CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+        $this->execute("ALTER TABLE `posts`                 CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+        $this->execute("ALTER TABLE `posts_tags`            CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+        $this->execute("ALTER TABLE `schema_migrations`     CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+        $this->execute("ALTER TABLE `table_data`            CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+        $this->execute("ALTER TABLE `tag_aliases`           CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+        $this->execute("ALTER TABLE `tag_implications`      CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+        $this->execute("ALTER TABLE `tag_subscriptions`     CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+        $this->execute("ALTER TABLE `tags`                  CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+        $this->execute("ALTER TABLE `user_blacklisted_tags` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+        $this->execute("ALTER TABLE `user_logs`             CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+        $this->execute("ALTER TABLE `user_records`          CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+        $this->execute("ALTER TABLE `users`                 CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+        $this->execute("ALTER TABLE `wiki_page_versions`    CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+        $this->execute("ALTER TABLE `wiki_pages`            CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+    }
+}


### PR DESCRIPTION
Sorry for the wall of text, but the second part of this is rather important. If you wish to discuss, post comments here before merging the pull request. Github doesn't notify me of new comments after the pull request is already merged.

## Migrations
This adds two database migrations.

The first will add missing constraints and indexes to help improve performance and data integrity. If you get an error when running the migration, it is probably because invalid data exists in the table and will need to be manually corrected or removed. After correcting the invalid data then just run the migration again. The original developers seem to have forgotten many foreign keys to the user table.

The second migration will convert all tables and text/char/varchar columns to use utf8mb4 character set with utf8mb4_unicode_ci collation for proper Unicode support. This could take some time to run.

You will also probably want to change the database default character set (if you haven't yet). I can't do this from a migration; you will need to run `ALTER DATABASE myimouto_db_name CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;`. This shouldn't really matter if all the tables use utf8mb4 but it is good practice anyway.

To run the migrations run `php config/boot.php db:migrate`

## Mojibake and Table Corruption Issue
I have done some more investigation on the charset and mojibake issue and I think the problem is worse than just the tables not using utf8mb4. The real culprit is that the server is configured in such a way that by default php uses latin1 rather than utf8 or utf8mb4 when connecting to the database and you do not explicitly set the connection character set it MyImouto's configuration. So the database is interpreting the data as utf8 while MyImouto is interpreting it as latin1. I am guessing your old server was configured such that php used utf8 by default; hence the mojibake when you migrated servers.

You can test this theory by explicitly configuring myimouto to use utf8mb4 by setting the charset option in database.yml like the following:
```
login: &login
  adapter: mysql
  host: 127.0.0.1
  username: myimouto
  password: myimouto
  charset: utf8mb4
```

If this causes massive mojibake again, then change it to explicitly use `latin1`. If the mojibake disappears when you change it to latin1 then MyImouto has indeed been using latin1 instead of utf8 since you migrated servers.

Unfortunately letting MyImouto keep using latin1 is not really an option. This is what is primarily causing table corruption and the problems in handling extended Unicode characters. I don't know of an easy way to deal with the mojibake automatically. We basically will have to go through the same ordeal as you did in forum thread #3709 again.

I don't know if you use any other databases for your other vhosts but this may or may not be a problem for your other vhosts as well depending if they explicitly set the connection charset or rely on the system defaults.