### PR TITLE
Fix CORS parenting issue, make order:random stable, add cache controls

### DIFF
--- a/app/controllers/ApplicationController.php
+++ b/app/controllers/ApplicationController.php
@@ -151,31 +151,50 @@ class ApplicationController extends Rails\ActionController\Base
     /**
      * Authorize a controller action to respond to CORS and handle CORS requests.
      * 
-     * \param $origins      The string '*' or an array of allowed origins
-     * \param $methods      An array of allowed HTTP methods
+     * \param $rules        A map where the keys are origins and the values are arrays of the allowed methods
+     *                      for the origin. The special key '#' can be used for a same origin policy and the
+     *                      '*' key can be used for all otherwise unspecified origins.
+     *
      * \param $maxage       Max time (seconds) client may cache CORS response or -1 to prevent caching
      *
      * \returns             True to indicate a CORS request was handled and no further processing should
      *                      be performed; otherwise false indicates normal processing should continue.
      */
-    protected function handle_cors($origins = '*', $methods = ['OPTIONS', 'GET'], $maxage = -1)
+    protected function handle_cors($rules, $maxage = -1)
     {
         $method = $_SERVER['REQUEST_METHOD'];
         $origin = isset($_SERVER['HTTP_ORIGIN']) ? $_SERVER['HTTP_ORIGIN'] : null;
+        $allmethods = ['OPTIONS'];
+        foreach(array_values($rules) as $r) { $allmethods = array_merge($allmethods, $r); }
+        $allmethods = array_unique($allmethods);
 
         if ($origin) // when origin is set then request is a CORS request
         {
-            if (is_string($origins) && $origins != '*') { $origins = [ $origins ]; }
-            if (!in_array('OPTIONS', $methods)) { array_push($methods, 'OPTIONS'); }
+            $scheme = $_SERVER['REQUEST_SCHEME'];
+            $domain = $_SERVER['SERVER_NAME'];
+            $ipaddr = $_SERVER['SERVER_ADDR'];
+            $port = $_SERVER['SERVER_PORT'];
 
-            // check if origin is allowed and output appropriate header
-            if ($origins == '*') {
-                header('Access-Control-Allow-Origin: *');
-            } else if (in_array($origin, $origins)) {
+            $self = [
+                "{$scheme}://{$domain}",
+                "{$scheme}://{$domain}:{$port}",
+                "{$scheme}://{$ipaddr}",
+                "{$scheme}://{$ipaddr}:{$port}",
+            ];
+
+            // check if origin is self
+            if (isset($rules[$origin])) {
                 header('Access-Control-Allow-Origin: ' . $origin);
+                $methods = $rules[$origin];
+            } else if (isset($rules['#']) && in_array($origin, $self)) {
+                header('Access-Control-Allow-Origin: ' . $origin);
+                $methods = $rules['#'];
+            } else if (isset($rules['*'])) {
+                header('Access-Control-Allow-Origin: *');
+                $methods = $rules['*'];
             } else if ($method == 'OPTIONS') {
                 // respond to invalid preflight, do not return CORS headers
-                header('Allow: ' . implode(', ', $methods));
+                header('Allow: ' . implode(', ', $allmethods));
                 $this->render(['nothing' => true, 'status' => 200]);
                 return true;
             } else { // invalid origin and not preflight so reject the request
@@ -183,12 +202,13 @@ class ApplicationController extends Rails\ActionController\Base
                 return true;
             }
 
+            if (!in_array('OPTIONS', $methods)) { array_unshift($methods, 'OPTIONS'); }
+
             // respond to a valid CORS preflight
             if ($method == 'OPTIONS') {
-                $smethods = implode(', ', $methods);
-                header('Access-Control-Allow-Methods: ' . $smethods);
+                header('Access-Control-Allow-Methods: ' . implode(', ', $methods));
                 header('Access-Control-Max-Age: ' . $maxage);
-                header('Allow: ' . $smethods);
+                header('Allow: ' . implode(', ', $allmethods));
                 $this->render(['nothing' => true, 'status' => 200]);
                 return true;
             }
@@ -200,7 +220,7 @@ class ApplicationController extends Rails\ActionController\Base
             }
 
         } else if ($method == 'OPTIONS') { // non-CORS request
-            header('Allow: ' . implode(', ', $methods));
+            header('Allow: ' . implode(', ', $allmethods));
             $this->render(['nothing' => true, 'status' => 200]);
             return true;
         }

--- a/app/controllers/ApplicationController.php
+++ b/app/controllers/ApplicationController.php
@@ -347,6 +347,33 @@ class ApplicationController extends Rails\ActionController\Base
         }
     }
 
+
+    /**
+     * Set cache control headers for client side caching.
+     * 
+     * \param $visibility   Can be 'no-store', 'no-cache', 'private', or 'public'
+     * \param $duration     Duration, in seconds, that the resource can be cached
+     * \param $revalidate   True if validation with server is required, false to allow stale responses
+     */
+    public function set_client_cache($visibility, $duration = 0, $revalidate = false)
+    {
+        if ($visibility == 'no-store') {
+            header("Cache-Control: no-store, max-age=0");
+            header('Expires: Sun, 11 Mar 1984 12:00:00 GMT');
+            header('Pragma: no-cache');
+        } else if ($visibility == 'no-cache' || ($duration == 0 && $revalidate)) {
+            header("Cache-Control: no-cache");
+            header('Expires: Sun, 11 Mar 1984 12:00:00 GMT');
+            header('Pragma: no-cache');
+        } else {
+            header("Cache-Control: {$visibility}, max-age={$duration}" . ($revalidate ? ', must-revalidate' : ''));
+            header('Expires: ' . gmdate(DATE_RFC7231, time() + $duration));
+            header_remove('Pragma');
+        }
+    }
+
+
+    // this does not appear to be used
     public function set_cache_headers()
     {
         $this->response()->headers()->add("Cache-Control", "max-age=300");

--- a/app/controllers/PostController.php
+++ b/app/controllers/PostController.php
@@ -398,8 +398,9 @@ class PostController extends ApplicationController
             }
         }
 
+        $seed = isset($this->params()->seed) ? intval(hash('fnv132', $this->params()->seed), 16) : mt_rand();
         $this->showing_holds_only = isset($q['show_holds']) && $q['show_holds'] == 'only';
-        list ($sql, $params) = Post::generate_sql($q, array('original_query' => $tags, 'from_api' => $from_api, 'order' => "p.id DESC", 'offset' => $offset, 'limit' => $posts_to_load));
+        list ($sql, $params) = Post::generate_sql($q, array('original_query' => $tags, 'from_api' => $from_api, 'order' => "p.id DESC", 'offset' => $offset, 'limit' => $posts_to_load, 'seed' => $seed));
 
         $results = Post::findBySql($sql, $params);
 

--- a/app/controllers/PostController.php
+++ b/app/controllers/PostController.php
@@ -432,6 +432,9 @@ class PostController extends ApplicationController
         if ($count < CONFIG()->post_index_default_limit && count($split_tags) == 1) {
             $this->tag_suggestions = Tag::find_suggestions($tags);
         }
+
+        $this->set_client_cache('private', $tags == '' ? CONFIG()->index_client_cache : CONFIG()->search_client_cache);
+
 // exit;
         $this->respondTo(array(
             'html' => function() use ($split_tags, $tags) {
@@ -524,6 +527,7 @@ class PostController extends ApplicationController
                 $this->following_pool_post = PoolPost::where("post_id = ?", $this->post->id)->first();
             }
 
+            $this->set_client_cache('private', CONFIG()->post_client_cache);
             $this->tags = array('include' => $this->post->tags());
             $this->include_tag_reverse_aliases = true;
             $this->set_title(str_replace('_', ' ', $this->post->title_tags()));

--- a/app/controllers/PostController.php
+++ b/app/controllers/PostController.php
@@ -329,7 +329,7 @@ class PostController extends ApplicationController
 
     public function index()
     {
-        if ($this->handle_cors('*', ['OPTIONS', 'GET'], 86400)) { return; }
+        if ($this->handle_cors(['#' => ['GET', 'POST'], '*' => ['GET']], 86400)) { return; }
 
         $tags = $this->params()->tags;
         $split_tags = $tags ? array_filter(explode(' ', $tags)) : array();

--- a/app/controllers/PostController.php
+++ b/app/controllers/PostController.php
@@ -329,7 +329,7 @@ class PostController extends ApplicationController
 
     public function index()
     {
-        if ($this->handle_cors(['#' => ['GET', 'POST'], '*' => ['GET']], 86400)) { return; }
+        if ($this->handle_cors(['#' => ['HEAD', 'GET', 'POST'], '*' => ['HEAD', 'GET']], 86400)) { return; }
 
         $tags = $this->params()->tags;
         $split_tags = $tags ? array_filter(explode(' ', $tags)) : array();

--- a/app/models/Post/SqlMethods.php
+++ b/app/models/Post/SqlMethods.php
@@ -417,7 +417,7 @@ trait PostSqlMethods
                     $sql .= " ORDER BY f.id DESC";
 
             } elseif ($q['order'] == "random")
-                $sql .= " ORDER BY RAND()";
+                $sql .= " ORDER BY RAND(" . (isset($options['seed']) ? $options['seed'] : '') . ")";
 
             else
                 $use_default_order = true;

--- a/app/views/post/_search.php
+++ b/app/views/post/_search.php
@@ -3,6 +3,7 @@
   <?= $this->formTag('post#index', array('method' => 'get', 'accept-charset' => 'UTF-8'), function(){ ?>
     <div style="margin:0;padding:0;display:inline"></div>
     <div>
+      <?= $this->hiddenFieldTag("seed", mt_rand()) ?>
       <?= $this->textFieldTag("tags", $this->h($this->params()->tags), array('size' => '20', 'autocomplete' => 'off')) ?>
       <?= $this->submitTag($this->t('.search'), array('style' => 'display: none;', 'name' => '')) ?>
     </div>

--- a/app/views/static/index.php
+++ b/app/views/static/index.php
@@ -10,6 +10,7 @@
   <div style="margin-bottom: 2em;">
     <?= $this->formTag('post#index', array('method' => "get"), function() { ?>
       <div>
+        <?= $this->hiddenFieldTag("seed", mt_rand()) ?>
         <?= $this->textFieldTag("tags", "", array('size' => 30)) ?><br />
         <?= $this->submitTag($this->t('static_search')) ?>
       </div>

--- a/config/default_config.php
+++ b/config/default_config.php
@@ -272,6 +272,16 @@ abstract class DefaultConfig
      * *******************************
      */
 
+    # Time, in seconds, client can cache the main index (empty query).
+    # This should be low as user will not see new posts (including their own) until cache expires.
+    public $index_client_cache = 30;
+
+    # Time, in seconds, client can cache search results (non-empty query).
+    public $search_client_cache = 300;
+
+    # Time, in seconds, client can cache a post.
+    public $post_client_cache = 300;
+
     # Default limit for /post
     public $post_index_default_limit = 16;
 

--- a/config/routes.php
+++ b/config/routes.php
@@ -1,9 +1,9 @@
 <?php
 MyImouto\Application::routes()->draw(function() {
     # Admin
-    $this->match('admin(/index)', 'admin#index', ['via' => ['get', 'post']]);
-    $this->match('admin/edit_user', ['via' => ['get', 'post']]);
-    $this->match('admin/reset_password', ['via' => ['get', 'post']]);
+    $this->match('admin(/index)', 'admin#index', ['via' => ['head', 'get', 'post']]);
+    $this->match('admin/edit_user', ['via' => ['head', 'get', 'post']]);
+    $this->match('admin/reset_password', ['via' => ['head', 'get', 'post']]);
     $this->post('admin/recalculate_tag_count');
     $this->post('admin/purge_tags');
 
@@ -18,19 +18,19 @@ MyImouto\Application::routes()->draw(function() {
     });
 
     # Artist
-    $this->match('artist(/index)(.:format)', 'artist#index', ['via' => ['get', 'post']]);
-    $this->match('artist/create(.:format)', ['via' => ['get', 'post']]);
-    $this->match('artist/destroy(.:format)(/:id)', 'artist#destroy', ['via' => ['get', 'post']]);
-    $this->match('artist/preview', ['via' => ['get', 'post']]);
-    $this->match('artist/show(/:id)', 'artist#show', ['via' => ['get', 'post']]);
-    $this->match('artist/update(.:format)(/:id)', 'artist#update', ['via' => ['get', 'post']]);
+    $this->match('artist(/index)(.:format)', 'artist#index', ['via' => ['head', 'get', 'post']]);
+    $this->match('artist/create(.:format)', ['via' => ['head', 'get', 'post']]);
+    $this->match('artist/destroy(.:format)(/:id)', 'artist#destroy', ['via' => ['head', 'get', 'post']]);
+    $this->match('artist/preview', ['via' => ['head', 'get', 'post']]);
+    $this->match('artist/show(/:id)', 'artist#show', ['via' => ['head', 'get', 'post']]);
+    $this->match('artist/update(.:format)(/:id)', 'artist#update', ['via' => ['head', 'get', 'post']]);
 
     # Banned
-    $this->match('banned(/index)', 'banned#index', ['via' => ['get', 'post']]);
+    $this->match('banned(/index)', 'banned#index', ['via' => ['head', 'get', 'post']]);
 
     # Batch
-    $this->match('batch(/index)', 'batch#index', ['via' => ['get', 'post']]);
-    $this->match('batch/create', ['via' => ['get', 'post']]);
+    $this->match('batch(/index)', 'batch#index', ['via' => ['head', 'get', 'post']]);
+    $this->match('batch/create', ['via' => ['head', 'get', 'post']]);
     $this->post('batch/enqueue');
     $this->post('batch/update');
 
@@ -39,38 +39,38 @@ MyImouto\Application::routes()->draw(function() {
     $this->post('blocks/unblock_ip');
 
     # Comment
-    $this->match('comment(/index)', 'comment#index', ['via' => ['get', 'post']]);
-    $this->match('comment/edit(/:id)', 'comment#edit', ['via' => ['get', 'post']]);
-    $this->match('comment/moderate', ['via' => ['get', 'post']]);
-    $this->match('comment/search', ['via' => ['get', 'post']]);
-    $this->match('comment/show(.:format)(/:id)', 'comment#show', ['via' => ['get', 'post']]);
+    $this->match('comment(/index)', 'comment#index', ['via' => ['head', 'get', 'post']]);
+    $this->match('comment/edit(/:id)', 'comment#edit', ['via' => ['head', 'get', 'post']]);
+    $this->match('comment/moderate', ['via' => ['head', 'get', 'post']]);
+    $this->match('comment/search', ['via' => ['head', 'get', 'post']]);
+    $this->match('comment/show(.:format)(/:id)', 'comment#show', ['via' => ['head', 'get', 'post']]);
     $this->match('comment/destroy(.:format)(/:id)', 'comment#destroy', ['via' => ['post', 'delete']]);
     $this->match('comment/update(/:id)', 'comment#update', ['via' => ['post', 'put']]);
     $this->post('comment/create(.:format)');
     $this->post('comment/mark_as_spam(/:id)', 'comment#mark_as_spam');
 
     # Dmail
-    $this->match('dmail(/inbox)', 'dmail#inbox', ['via' => ['get', 'post']]);
-    $this->match('dmail/compose', ['via' => ['get', 'post']]);
-    $this->match('dmail/preview', ['via' => ['get', 'post']]);
-    $this->match('dmail/show(/:id)', 'dmail#show', ['via' => ['get', 'post']]);
-    $this->match('dmail/show_previous_messages', ['via' => ['get', 'post']]);
+    $this->match('dmail(/inbox)', 'dmail#inbox', ['via' => ['head', 'get', 'post']]);
+    $this->match('dmail/compose', ['via' => ['head', 'get', 'post']]);
+    $this->match('dmail/preview', ['via' => ['head', 'get', 'post']]);
+    $this->match('dmail/show(/:id)', 'dmail#show', ['via' => ['head', 'get', 'post']]);
+    $this->match('dmail/show_previous_messages', ['via' => ['head', 'get', 'post']]);
     $this->post('dmail/create');
     $this->get('dmail/mark_all_read', 'dmail#confirm_mark_all_read');
     $this->post('dmail/mark_all_read');
 
     # Favorite
-    $this->match('favorite/list_users(.:format)', ['via' => ['get', 'post']]);
+    $this->match('favorite/list_users(.:format)', ['via' => ['head', 'get', 'post']]);
 
     # Forum
-    $this->match('forum(/index)(.:format)', 'forum#index', ['via' => ['get', 'post']]);
-    $this->match('forum/preview', ['via' => ['get', 'post']]);
-    $this->match('forum/new', 'forum#blank', ['via' => ['get', 'post']]);
-    $this->match('forum/add', ['via' => ['get', 'post']]);
-    $this->match('forum/edit(/:id)', 'forum#edit', ['via' => ['get', 'post']]);
-    $this->match('forum/show(/:id)', 'forum#show', ['via' => ['get', 'post']]);
-    $this->match('forum/search', ['via' => ['get', 'post']]);
-    $this->match('forum/mark_all_read', ['via' => ['get', 'post']]);
+    $this->match('forum(/index)(.:format)', 'forum#index', ['via' => ['head', 'get', 'post']]);
+    $this->match('forum/preview', ['via' => ['head', 'get', 'post']]);
+    $this->match('forum/new', 'forum#blank', ['via' => ['head', 'get', 'post']]);
+    $this->match('forum/add', ['via' => ['head', 'get', 'post']]);
+    $this->match('forum/edit(/:id)', 'forum#edit', ['via' => ['head', 'get', 'post']]);
+    $this->match('forum/show(/:id)', 'forum#show', ['via' => ['head', 'get', 'post']]);
+    $this->match('forum/search', ['via' => ['head', 'get', 'post']]);
+    $this->match('forum/mark_all_read', ['via' => ['head', 'get', 'post']]);
     $this->match('forum/lock', ['via' => ['post', 'put']]);
     $this->match('forum/stick(/:id)', 'forum#stick', ['via' => ['post', 'put']]);
     $this->match('forum/unlock(/:id)', 'forum#unlock', ['via' => ['post', 'put']]);
@@ -80,101 +80,101 @@ MyImouto\Application::routes()->draw(function() {
     $this->post('forum/create');
 
     # Help
-    $this->match('help(/index)', 'help#index', ['via' => ['get', 'post']]);
-    $this->match('help/:action', 'help#:action', ['via' => ['get', 'post']]);
+    $this->match('help(/index)', 'help#index', ['via' => ['head', 'get', 'post']]);
+    $this->match('help/:action', 'help#:action', ['via' => ['head', 'get', 'post']]);
 
     # History
-    $this->match('history(/index)', 'history#index', ['via' => ['get', 'post']]);
+    $this->match('history(/index)', 'history#index', ['via' => ['head', 'get', 'post']]);
     $this->post('history/undo');
 
     # Inline
-    $this->match('inline(/index)', 'inline#index', ['via' => ['get', 'post']]);
-    $this->match('inline/add_image(/:id)', 'inline#add_image', ['via' => ['get', 'post']]);
-    $this->match('inline/create', ['via' => ['get', 'post']]);
-    $this->match('inline/crop(/:id)', 'inline#crop', ['via' => ['get', 'post']]);
-    $this->match('inline/edit(/:id)', 'inline#edit', ['via' => ['get', 'post']]);
+    $this->match('inline(/index)', 'inline#index', ['via' => ['head', 'get', 'post']]);
+    $this->match('inline/add_image(/:id)', 'inline#add_image', ['via' => ['head', 'get', 'post']]);
+    $this->match('inline/create', ['via' => ['head', 'get', 'post']]);
+    $this->match('inline/crop(/:id)', 'inline#crop', ['via' => ['head', 'get', 'post']]);
+    $this->match('inline/edit(/:id)', 'inline#edit', ['via' => ['head', 'get', 'post']]);
     $this->match('inline/copy(/:id)', 'inline#copy', ['via' => ['post', 'put']]);
     $this->match('inline/update(/:id)', 'inline#update', ['via' => ['post', 'put']]);
     $this->match('inline/delete(/:id)', 'inline#delete', ['via' => ['post', 'delete']]);
     $this->match('inline/delete_image(/:id)', 'inline#delete_image', ['via' => ['post', 'delete']]);
 
     # JobTask
-    $this->match('job_task(/index)', 'job_task#index', ['via' => ['get', 'post']]);
-    $this->match('job_task/destroy(/:id)', 'job_task#destroy', ['via' => ['get', 'post']]);
-    $this->match('job_task/restart(/:id)', 'job_task#restart', ['via' => ['get', 'post']]);
-    $this->match('job_task/show(/:id)', 'job_task#show', ['via' => ['get', 'post']]);
+    $this->match('job_task(/index)', 'job_task#index', ['via' => ['head', 'get', 'post']]);
+    $this->match('job_task/destroy(/:id)', 'job_task#destroy', ['via' => ['head', 'get', 'post']]);
+    $this->match('job_task/restart(/:id)', 'job_task#restart', ['via' => ['head', 'get', 'post']]);
+    $this->match('job_task/show(/:id)', 'job_task#show', ['via' => ['head', 'get', 'post']]);
 
     # Note
-    $this->match('note(/index)(.:format)', 'note#index', ['via' => ['get', 'post']]);
-    $this->match('note/history(.:format)(/:id)', 'note#history', ['via' => ['get', 'post']]);
-    $this->match('note/search(.:format)', ['via' => ['get', 'post']]);
+    $this->match('note(/index)(.:format)', 'note#index', ['via' => ['head', 'get', 'post']]);
+    $this->match('note/history(.:format)(/:id)', 'note#history', ['via' => ['head', 'get', 'post']]);
+    $this->match('note/search(.:format)', ['via' => ['head', 'get', 'post']]);
     $this->match('note/revert(.:format)(/:id)', 'note#revert', ['via' => ['post', 'put']]);
     $this->match('note/update(.:format)(/:id)', 'note#update', ['via' => ['post', 'put']]);
 
     # Pool
-    $this->match('pool(/index)(.:format)', 'pool#index', ['via' => ['get', 'post']]);
-    $this->match('pool/add_post(.:format)', 'pool#add_post', ['via' => ['get', 'post']]);
-    $this->match('pool/copy(/:id)', 'pool#copy', ['via' => ['get', 'post']]);
-    $this->match('pool/create(.:format)', 'pool#create', ['via' => ['get', 'post']]);
-    $this->match('pool/destroy(.:format)(/:id)', 'pool#destroy', ['via' => ['get', 'post']]);
-    $this->match('pool/import(/:id)', 'pool#import', ['via' => ['get', 'post']]);
-    $this->match('pool/order(/:id)', 'pool#order', ['via' => ['get', 'post']]);
-    $this->match('pool/remove_post(.:format)', 'pool#remove_post', ['via' => ['get', 'post']]);
-    $this->match('pool/select', ['via' => ['get', 'post']]);
-    $this->match('pool/show(.:format)(/:id)', 'pool#show', ['via' => ['get', 'post']]);
-    $this->match('pool/transfer_metadata', ['via' => ['get', 'post']]);
-    $this->match('pool/update(.:format)(/:id)', 'pool#update', ['via' => ['get', 'post']]);
-    $this->match('pool/zip/:id/:filename', 'pool#zip', ['constraints' => ['filename' => '/.*/'], 'via' => ['get', 'post']]);
+    $this->match('pool(/index)(.:format)', 'pool#index', ['via' => ['head', 'get', 'post']]);
+    $this->match('pool/add_post(.:format)', 'pool#add_post', ['via' => ['head', 'get', 'post']]);
+    $this->match('pool/copy(/:id)', 'pool#copy', ['via' => ['head', 'get', 'post']]);
+    $this->match('pool/create(.:format)', 'pool#create', ['via' => ['head', 'get', 'post']]);
+    $this->match('pool/destroy(.:format)(/:id)', 'pool#destroy', ['via' => ['head', 'get', 'post']]);
+    $this->match('pool/import(/:id)', 'pool#import', ['via' => ['head', 'get', 'post']]);
+    $this->match('pool/order(/:id)', 'pool#order', ['via' => ['head', 'get', 'post']]);
+    $this->match('pool/remove_post(.:format)', 'pool#remove_post', ['via' => ['head', 'get', 'post']]);
+    $this->match('pool/select', ['via' => ['head', 'get', 'post']]);
+    $this->match('pool/show(.:format)(/:id)', 'pool#show', ['via' => ['head', 'get', 'post']]);
+    $this->match('pool/transfer_metadata', ['via' => ['head', 'get', 'post']]);
+    $this->match('pool/update(.:format)(/:id)', 'pool#update', ['via' => ['head', 'get', 'post']]);
+    $this->match('pool/zip/:id/:filename', 'pool#zip', ['constraints' => ['filename' => '/.*/'], 'via' => ['head', 'get', 'post']]);
 
     # Post
-    $this->match('post(/index)(.:format)', 'post#index', ['via' => ['get', 'post', 'options']]);
-    $this->match('post/acknowledge_new_deleted_posts', ['via' => ['get', 'post']]);
-    $this->match('post/activate', ['via' => ['get', 'post']]);
-    $this->match('post/atom(.:format)', 'post#atom', ['format' => 'atom', 'via' => ['get', 'post']]);
-    $this->match('post/browse', ['via' => ['get', 'post']]);
-    $this->match('post/delete(/:id)', 'post#delete', ['via' => ['get', 'post']]);
-    $this->match('post/deleted_index', ['via' => ['get', 'post']]);
-    $this->match('post/download', ['via' => ['get', 'post']]);
-    $this->match('post/error', ['via' => ['get', 'post']]);
-    $this->match('post/exception', ['via' => ['get', 'post']]);
+    $this->match('post(/index)(.:format)', 'post#index', ['via' => ['head', 'get', 'post', 'options']]);
+    $this->match('post/acknowledge_new_deleted_posts', ['via' => ['head', 'get', 'post']]);
+    $this->match('post/activate', ['via' => ['head', 'get', 'post']]);
+    $this->match('post/atom(.:format)', 'post#atom', ['format' => 'atom', 'via' => ['head', 'get', 'post']]);
+    $this->match('post/browse', ['via' => ['head', 'get', 'post']]);
+    $this->match('post/delete(/:id)', 'post#delete', ['via' => ['head', 'get', 'post']]);
+    $this->match('post/deleted_index', ['via' => ['head', 'get', 'post']]);
+    $this->match('post/download', ['via' => ['head', 'get', 'post']]);
+    $this->match('post/error', ['via' => ['head', 'get', 'post']]);
+    $this->match('post/exception', ['via' => ['head', 'get', 'post']]);
     // $this->match('post/histogram');
-    $this->match('post/moderate', ['via' => ['get', 'post']]);
-    $this->match('post/piclens', ['format' => 'rss', 'via' => ['get', 'post']]);
-    $this->match('post/popular_by_day', ['via' => ['get', 'post']]);
-    $this->match('post/popular_by_month', ['via' => ['get', 'post']]);
-    $this->match('post/popular_by_week', ['via' => ['get', 'post']]);
-    $this->match('post/popular_recent', ['via' => ['get', 'post']]);
-    $this->match('post/random(/:id)', 'post#random', ['via' => ['get', 'post']]);
-    $this->match('post/show(/:id)(/*tag_title)', 'post#show', ['constraints' => ['id' => '/^\d+$/'], 'format' => false, 'via' => ['get', 'post']]);
-    $this->match('post/similar(/:id)', 'post#similar', ['via' => ['get', 'post']]);
-    $this->match('post/undelete(/:id)', 'post#undelete', ['via' => ['get', 'post']]);
-    $this->match('post/update_batch', ['via' => ['get', 'post']]);
-    $this->match('post/upload', ['via' => ['get', 'post']]);
-    $this->match('post/upload_problem', ['via' => ['get', 'post']]);
-    $this->match('post/view(/:id)', 'post#view', ['via' => ['get', 'post']]);
-    $this->match('post/flag(/:id)', 'post#flag', ['via' => ['post', 'put']]);
+    $this->match('post/moderate', ['via' => ['head', 'get', 'post']]);
+    $this->match('post/piclens', ['format' => 'rss', 'via' => ['head', 'get', 'post']]);
+    $this->match('post/popular_by_day', ['via' => ['head', 'get', 'post']]);
+    $this->match('post/popular_by_month', ['via' => ['head', 'get', 'post']]);
+    $this->match('post/popular_by_week', ['via' => ['head', 'get', 'post']]);
+    $this->match('post/popular_recent', ['via' => ['head', 'get', 'post']]);
+    $this->match('post/random(/:id)', 'post#random', ['via' => ['head', 'get', 'post']]);
+    $this->match('post/show(/:id)(/*tag_title)', 'post#show', ['constraints' => ['id' => '/^\d+$/'], 'format' => false, 'via' => ['head', 'get', 'post']]);
+    $this->match('post/similar(/:id)', 'post#similar', ['via' => ['head', 'get', 'post']]);
+    $this->match('post/undelete(/:id)', 'post#undelete', ['via' => ['head', 'get', 'post']]);
+    $this->match('post/update_batch', ['via' => ['head', 'get', 'post']]);
+    $this->match('post/upload', ['via' => ['head', 'get', 'post']]);
+    $this->match('post/upload_problem', ['via' => ['head', 'get', 'post']]);
+    $this->match('post/view(/:id)', 'post#view', ['via' => ['head', 'get', 'post']]);
+    $this->match('post/flag(/:id)', 'post#flag', ['via' => ['head', 'post', 'put']]);
     $this->match('post/revert_tags(.:format)(/:id)', 'post#revert_tags', ['via' => ['post', 'put']]);
     $this->match('post/update(.:format)(/:id)', 'post#update', ['via' => ['post', 'put']]);
     $this->match('post/vote(.:format)(/:id)', 'post#vote', ['via' => ['post', 'put']]);
     $this->match('post/destroy(.:format)(/:id)', 'post#destroy', ['via' => ['post', 'delete']]);
-    $this->post('post/create(.:format)', 'post#create', ['via' => ['get', 'post']]);
-    $this->match('post/import', ['via' => ['get', 'post']]);
-    $this->match('post/search_external_data', ['via' => ['get', 'post']]);
+    $this->post('post/create(.:format)', 'post#create', ['via' => ['head', 'get', 'post']]);
+    $this->match('post/import', ['via' => ['head', 'get', 'post']]);
+    $this->match('post/search_external_data', ['via' => ['head', 'get', 'post']]);
 
-    $this->match('atom', 'post#atom', ['format' => 'atom', 'via' => ['get', 'post']]);
-    $this->match('download', 'post#download', ['via' => ['get', 'post']]);
-    $this->match('histogram', 'post#histogram', ['via' => ['get', 'post']]);
+    $this->match('atom', 'post#atom', ['format' => 'atom', 'via' => ['head', 'get', 'post']]);
+    $this->match('download', 'post#download', ['via' => ['head', 'get', 'post']]);
+    $this->match('histogram', 'post#histogram', ['via' => ['head', 'get', 'post']]);
 
     # PostTagHistory
-    $this->match('post_tag_history(/index)', 'post_tag_history#index', ['via' => ['get', 'post']]);
+    $this->match('post_tag_history(/index)', 'post_tag_history#index', ['via' => ['head', 'get', 'post']]);
 
     # Report
-    $this->match('report/tag_updates', ['via' => ['get', 'post']]);
-    $this->match('report/note_updates', ['via' => ['get', 'post']]);
-    $this->match('report/wiki_updates', ['via' => ['get', 'post']]);
-    $this->match('report/post_uploads', ['via' => ['get', 'post']]);
-    $this->match('report/votes', ['via' => ['get', 'post']]);
-    $this->match('report/set_dates', ['via' => ['get', 'post']]);
+    $this->match('report/tag_updates', ['via' => ['head', 'get', 'post']]);
+    $this->match('report/note_updates', ['via' => ['head', 'get', 'post']]);
+    $this->match('report/wiki_updates', ['via' => ['head', 'get', 'post']]);
+    $this->match('report/post_uploads', ['via' => ['head', 'get', 'post']]);
+    $this->match('report/votes', ['via' => ['head', 'get', 'post']]);
+    $this->match('report/set_dates', ['via' => ['head', 'get', 'post']]);
     
     # Settings
     $this->namespaced('settings', function() {
@@ -182,66 +182,66 @@ MyImouto\Application::routes()->draw(function() {
     });
 
     # Static
-    $this->match('static/500', ['via' => ['get', 'post']]);
-    $this->match('static/more', ['via' => ['get', 'post']]);
-    $this->match('static/terms_of_service', ['via' => ['get', 'post']]);
+    $this->match('static/500', ['via' => ['head', 'get', 'post']]);
+    $this->match('static/more', ['via' => ['head', 'get', 'post']]);
+    $this->match('static/terms_of_service', ['via' => ['head', 'get', 'post']]);
     // $this->match('/opensearch', 'static#opensearch', ['via' => ['get', 'post']]);
 
     # TagAlias
-    $this->match('tag_alias(/index)', 'tag_alias#index', ['via' => ['get', 'post']]);
+    $this->match('tag_alias(/index)', 'tag_alias#index', ['via' => ['head', 'get', 'post']]);
     $this->match('tag_alias/update', ['via' => ['post', 'put']]);
     $this->post('tag_alias/create');
 
     # Tag
-    $this->match('tag(/index)(.:format)', 'tag#index', ['via' => ['get', 'post']]);
+    $this->match('tag(/index)(.:format)', 'tag#index', ['via' => ['head', 'get', 'post']]);
     $this->get('tag/autocomplete_name', ['as' => 'ac_tag_name']);
-    $this->match('tag/cloud', ['via' => ['get', 'post']]);
-    $this->match('tag/edit(/:id)', 'tag#edit', ['via' => ['get', 'post']]);
-    $this->match('tag/edit_preview', ['via' => ['get', 'post']]);
-    $this->match('tag/mass_edit', ['via' => ['get', 'post']]);
-    $this->match('tag/popular_by_day', ['via' => ['get', 'post']]);
-    $this->match('tag/popular_by_month', ['via' => ['get', 'post']]);
-    $this->match('tag/popular_by_week', ['via' => ['get', 'post']]);
-    $this->match('tag/related(.:format)', 'tag#related', ['via' => ['get', 'post']]);
-    $this->match('tag/show(/:id)', 'tag#show', ['via' => ['get', 'post']]);
-    $this->match('tag/summary', ['via' => ['get', 'post']]);
-    $this->match('tag/update(.:format)', 'tag#update', ['via' => ['get', 'post']]);
-    $this->match('tag/fix_count', ['via' => ['get', 'post']]);
-    $this->match('tag/delete', ['via' => ['get', 'post']]);
+    $this->match('tag/cloud', ['via' => ['head', 'get', 'post']]);
+    $this->match('tag/edit(/:id)', 'tag#edit', ['via' => ['head', 'get', 'post']]);
+    $this->match('tag/edit_preview', ['via' => ['head', 'get', 'post']]);
+    $this->match('tag/mass_edit', ['via' => ['head', 'get', 'post']]);
+    $this->match('tag/popular_by_day', ['via' => ['head', 'get', 'post']]);
+    $this->match('tag/popular_by_month', ['via' => ['head', 'get', 'post']]);
+    $this->match('tag/popular_by_week', ['via' => ['head', 'get', 'post']]);
+    $this->match('tag/related(.:format)', 'tag#related', ['via' => ['head', 'get', 'post']]);
+    $this->match('tag/show(/:id)', 'tag#show', ['via' => ['head', 'get', 'post']]);
+    $this->match('tag/summary', ['via' => ['head', 'get', 'post']]);
+    $this->match('tag/update(.:format)', 'tag#update', ['via' => ['head', 'get', 'post']]);
+    $this->match('tag/fix_count', ['via' => ['head', 'get', 'post']]);
+    $this->match('tag/delete', ['via' => ['head', 'get', 'post']]);
 
     # TagImplication
-    $this->match('tag_implication(/index)', 'tag_implication#index', ['via' => ['get', 'post']]);
+    $this->match('tag_implication(/index)', 'tag_implication#index', ['via' => ['head', 'get', 'post']]);
     $this->match('tag_implication/update', ['via' => ['post', 'put']]);
     $this->post('tag_implication/create');
 
     # TagSubscription
-    $this->match('tag_subscription(/index)', 'tag_subscription#index', ['via' => ['get', 'post']]);
-    $this->match('tag_subscription/create', ['via' => ['get', 'post']]);
-    $this->match('tag_subscription/update', ['via' => ['get', 'post']]);
-    $this->match('tag_subscription/destroy(/:id)', 'tag_subscription#destroy', ['via' => ['get', 'post']]);
+    $this->match('tag_subscription(/index)', 'tag_subscription#index', ['via' => ['head', 'get', 'post']]);
+    $this->match('tag_subscription/create', ['via' => ['head', 'get', 'post']]);
+    $this->match('tag_subscription/update', ['via' => ['head', 'get', 'post']]);
+    $this->match('tag_subscription/destroy(/:id)', 'tag_subscription#destroy', ['via' => ['head', 'get', 'post']]);
 
     # User
     $this->get('user/autocomplete_name', ['as' => 'ac_user_name']);
-    $this->match('user(/index)(.:format)', 'user#index', ['via' => ['get', 'post']]);
-    $this->match('user/activate_user', ['via' => ['get', 'post']]);
-    $this->match('user/block(/:id)', 'user#block', ['via' => ['get', 'post']]);
-    $this->match('user/change_email', ['via' => ['get', 'post'], 'as' => 'user_change_email']);
-    $this->match('user/change_password', ['via' => ['get', 'post'], 'as' => 'user_change_password']);
-    $this->match('user/check', ['via' => ['get', 'post']]);
-    $this->match('user/edit', ['via' => ['get', 'post']]);
-    $this->match('user/error', ['via' => ['get', 'post']]);
-    $this->match('user/home', ['via' => ['get', 'post']]);
-    $this->match('user/invites', ['via' => ['get', 'post']]);
-    $this->match('user/login', ['via' => ['get', 'post']]);
-    $this->match('user/logout', ['via' => ['get', 'post']]);
-    $this->match('user/remove_from_blacklist', ['via' => ['get', 'post']]);
-    $this->match('user/resend_confirmation', ['via' => ['get', 'post']]);
-    $this->match('user/reset_password', ['via' => ['get', 'post']]);
-    $this->match('user/set_avatar(/:id)', 'user#set_avatar', ['via' => ['get', 'post']]);
-    $this->match('user/show(/:id)', 'user#show', ['via' => ['get', 'post']]);
-    $this->match('user/show_blocked_users', ['via' => ['get', 'post']]);
-    $this->match('user/signup', ['via' => ['get', 'post']]);
-    $this->match('user/unblock', ['via' => ['get', 'post']]);
+    $this->match('user(/index)(.:format)', 'user#index', ['via' => ['head', 'get', 'post']]);
+    $this->match('user/activate_user', ['via' => ['head', 'get', 'post']]);
+    $this->match('user/block(/:id)', 'user#block', ['via' => ['head', 'get', 'post']]);
+    $this->match('user/change_email', ['via' => ['head', 'get', 'post'], 'as' => 'user_change_email']);
+    $this->match('user/change_password', ['via' => ['head', 'get', 'post'], 'as' => 'user_change_password']);
+    $this->match('user/check', ['via' => ['head', 'get', 'post']]);
+    $this->match('user/edit', ['via' => ['head', 'get', 'post']]);
+    $this->match('user/error', ['via' => ['head', 'get', 'post']]);
+    $this->match('user/home', ['via' => ['head', 'get', 'post']]);
+    $this->match('user/invites', ['via' => ['head', 'get', 'post']]);
+    $this->match('user/login', ['via' => ['head', 'get', 'post']]);
+    $this->match('user/logout', ['via' => ['head', 'get', 'post']]);
+    $this->match('user/remove_from_blacklist', ['via' => ['head', 'get', 'post']]);
+    $this->match('user/resend_confirmation', ['via' => ['head', 'get', 'post']]);
+    $this->match('user/reset_password', ['via' => ['head', 'get', 'post']]);
+    $this->match('user/set_avatar(/:id)', 'user#set_avatar', ['via' => ['head', 'get', 'post']]);
+    $this->match('user/show(/:id)', 'user#show', ['via' => ['head', 'get', 'post']]);
+    $this->match('user/show_blocked_users', ['via' => ['head', 'get', 'post']]);
+    $this->match('user/signup', ['via' => ['head', 'get', 'post']]);
+    $this->match('user/unblock', ['via' => ['head', 'get', 'post']]);
     $this->match('user/authenticate', ['via' => ['post', 'put']]);
     $this->match('user/modify_blacklist', ['via' => ['post', 'put']]);
     $this->match('user/update', ['via' => ['post', 'put']]);
@@ -249,20 +249,20 @@ MyImouto\Application::routes()->draw(function() {
     $this->post('user/remove_avatar/:id', 'user#remove_avatar');
 
     # UserRecord
-    $this->match('user_record(/index)', 'user_record#index', ['via' => ['get', 'post']]);
-    $this->match('user_record/create(/:id)', 'user_record#create', ['via' => ['get', 'post']]);
+    $this->match('user_record(/index)', 'user_record#index', ['via' => ['head', 'get', 'post']]);
+    $this->match('user_record/create(/:id)', 'user_record#create', ['via' => ['head', 'get', 'post']]);
     $this->match('user_record/destroy(/:id)', 'user_record#destroy', ['via' => ['post', 'delete']]);
 
     # Wiki
-    $this->match('wiki(/index)(.:format)', 'wiki#index', ['via' => ['get', 'post']]);
-    $this->match('wiki/add', ['via' => ['get', 'post']]);
-    $this->match('wiki/diff', ['via' => ['get', 'post']]);
-    $this->match('wiki/edit', ['via' => ['get', 'post']]);
-    $this->match('wiki/history(.:format)(/:id)', 'wiki#history', ['via' => ['get', 'post']]);
-    $this->match('wiki/preview', ['via' => ['get', 'post']]);
-    $this->match('wiki/recent_changes', ['via' => ['get', 'post']]);
-    $this->match('wiki/rename', ['via' => ['get', 'post']]);
-    $this->match('wiki/show(.:format)', 'wiki#show', ['via' => ['get', 'post']]);
+    $this->match('wiki(/index)(.:format)', 'wiki#index', ['via' => ['head', 'get', 'post']]);
+    $this->match('wiki/add', ['via' => ['head', 'get', 'post']]);
+    $this->match('wiki/diff', ['via' => ['head', 'get', 'post']]);
+    $this->match('wiki/edit', ['via' => ['head', 'get', 'post']]);
+    $this->match('wiki/history(.:format)(/:id)', 'wiki#history', ['via' => ['head', 'get', 'post']]);
+    $this->match('wiki/preview', ['via' => ['head', 'get', 'post']]);
+    $this->match('wiki/recent_changes', ['via' => ['head', 'get', 'post']]);
+    $this->match('wiki/rename', ['via' => ['head', 'get', 'post']]);
+    $this->match('wiki/show(.:format)', 'wiki#show', ['via' => ['head', 'get', 'post']]);
     $this->match('wiki/lock(.:format)', 'wiki#lock', ['via' => ['post', 'put']]);
     $this->match('wiki/revert(.:format)', 'wiki#revert', ['via' => ['post', 'put']]);
     $this->match('wiki/unlock(.:format)', 'wiki#unlock', ['via' => ['post', 'put']]);


### PR DESCRIPTION
First this fixes the problem with CORS. This will now allow same origin POST by ajax so things like the re-parenting will work. POST from remote origin is still not allowed. Allowing cross-origin POST has many security implications and with the current design of the API is probably unsafe.

Second, I added a `seed` parameter to searches to make searches with order:random stable. As long as the seed parameter is the same, and no new posts match the search criteria, the results will have the same order. When searching by the form, it will generate a random seed which will be retained while navigating through the search results.

Third, I added some options to the config that will allow you some control over client side caching. See the default_config.php for details. I advise caution using these though as users will not see changes to posts and search results until the cache expires or they explicitly refresh the page. The correct way to handle caching of dynamic content is to use etags. I will look into adding support for etags later but it will require more significant changes.

You will also need to undo whatever server configuration changes you have done to make the server currently return two cache-control headers. This is invalid and likely confusing browsers.

Changes to the views means you will need to delete the server cache when applying these changes.
