### PR TITLE
Added feature to allow users to customize file downloads

### DIFF
--- a/app/controllers/ArtistController.php
+++ b/app/controllers/ArtistController.php
@@ -100,7 +100,8 @@ class ArtistController extends ApplicationController
         $query = Artist::none();
         
         $page = $this->page_number();
-        $per_page = 50;
+        $per_page = $this->params()->limit;
+        $per_page = is_numeric($per_page) ? intval($per_page) : 50;
         
         if ($this->params()->name && !$aliases_only)
             $query = Artist::generate_sql($this->params()->name);

--- a/app/controllers/ArtistController.php
+++ b/app/controllers/ArtistController.php
@@ -27,7 +27,8 @@ class ArtistController extends ApplicationController
         $this->artist = Artist::find($this->params()->id);
 
          if ($this->request()->isPost()) {
-             if ($this->params()->commit == "Yes") {
+            // API wont have commit button so flip the logic, check for the no button to fix the API.
+            if ($this->params()->commit != "No") {
                 $this->artist->destroy();
                 $this->respond_to_success("Artist deleted", ['#index', 'page' => $this->page_number()]);
             } else {

--- a/app/controllers/ArtistController.php
+++ b/app/controllers/ArtistController.php
@@ -115,7 +115,11 @@ class ArtistController extends ApplicationController
         
         $this->artists = $query->paginate($page, $per_page);
 
-        $this->respond_to_list("artists");
+        $this->respondTo([
+            'html',
+            'xml',
+            'json' => function() { $this->render(['json' => $this->artists->toJson()]); },
+        ]);
     }
 
     public function show()

--- a/app/controllers/CommentController.php
+++ b/app/controllers/CommentController.php
@@ -80,7 +80,11 @@ class CommentController extends ApplicationController
             $limit = $this->params()->limit;
             $limit = is_numeric($limit) ? intval($limit) : 25;
             $this->comments = Comment::generate_sql($this->params()->all())->order("id DESC")->paginate($this->page_number(), $limit);
-            $this->respond_to_list("comments");
+            $this->respondTo([
+                'html',
+                'xml',
+                'json' => function() { $this->render(['json' => $this->comments->toJson() ]); }
+            ]);
         } else {
             $this->posts = Post::where("last_commented_at IS NOT NULL")->order("last_commented_at DESC")->paginate($this->page_number(), 10);
 

--- a/app/controllers/CommentController.php
+++ b/app/controllers/CommentController.php
@@ -69,7 +69,11 @@ class CommentController extends ApplicationController
     {
         $this->set_title('Comment');
         $this->comment = Comment::find($this->params()->id);
-        $this->respond_to_list("comment");
+        $this->respondTo([
+            'html',
+            'xml',
+            'json' => function() { $this->render(['json' => $this->comment->toJson() ]); }
+        ]);
     }
 
     public function index()

--- a/app/controllers/CommentController.php
+++ b/app/controllers/CommentController.php
@@ -77,7 +77,9 @@ class CommentController extends ApplicationController
         $this->set_title('Comments');
         
         if ($this->request()->format() == "json" || $this->request()->format() == "xml") {
-            $this->comments = Comment::generate_sql($this->params()->all())->order("id DESC")->paginate($this->page_number(), 25);
+            $limit = $this->params()->limit;
+            $limit = is_numeric($limit) ? intval($limit) : 25;
+            $this->comments = Comment::generate_sql($this->params()->all())->order("id DESC")->paginate($this->page_number(), $limit);
             $this->respond_to_list("comments");
         } else {
             $this->posts = Post::where("last_commented_at IS NOT NULL")->order("last_commented_at DESC")->paginate($this->page_number(), 10);

--- a/app/controllers/NoteController.php
+++ b/app/controllers/NoteController.php
@@ -61,7 +61,11 @@ class NoteController extends ApplicationController
             $this->notes = NoteVersion::order("id DESC")->paginate($this->page_number(), 25);
         }
 
-        $this->respond_to_list("notes");
+        $this->respondTo([
+            'html',
+            'xml',
+            'json' => function() { $this->render(['json' => $this->notes]); }
+        ]);
     }
 
     // public function revert()

--- a/app/controllers/NoteController.php
+++ b/app/controllers/NoteController.php
@@ -36,18 +36,14 @@ class NoteController extends ApplicationController
         } else {
             $this->posts = Post::where("last_noted_at IS NOT NULL")->order("last_noted_at DESC")->paginate($this->page_number(), 16);
         }
-        # iTODO:
+
+        $this->notes = new Rails\ActiveRecord\Collection();
+        foreach ($this->posts as $post) { $this->notes->merge($post->notes); }
+
         $this->respondTo([
             'html',
-            'xml' => function() {
-                $notes = new Rails\ActiveRecord\Collection();
-                foreach ($this->posts as $post)
-                    $notes->merge($post->notes);
-                $this->render(['xml' => $notes, 'root' => "notes"]);
-            },
-            'json' => function() {
-                 // {render :json => @posts.map {|x| x.notes}.flatten.to_json}
-            }
+            'xml',
+            'json' => function() { $this->render(['json' => $this->notes]); }
         ]);
     }
 

--- a/app/controllers/PostController.php
+++ b/app/controllers/PostController.php
@@ -49,21 +49,18 @@ class PostController extends ApplicationController
             $user_id = current_user()->id;
         }
 
-        // $is_upload = array_key_exists('post', $_FILES);
+        $tmpfile_path = isset($_FILES['post']) ? $_FILES['post']['tmp_name']['file'] : null;
+        $tmpfile_name = isset($_FILES['post']) ? $_FILES['post']['name']['file'] : null;
 
-        # iTODO
         $post_params = array_merge($this->params()->post ?: array(), array(
             'updater_user_id' => current_user()->id,
             'updater_ip_addr' => $this->request()->remoteIp(),
             'user_id'         => current_user()->id,
             'ip_addr'         => $this->request()->remoteIp(),
             'status'          => $status,
-            'tempfile_path'   => $_FILES['post']['tmp_name']['file'],
-            'tempfile_name'   => $_FILES['post']['name']['file'],
-            'is_import'       => false, # Make sure to keep this value false
-            // 'tempfile_path'   => $is_upload ? $_FILES['post']['tmp_name']['file'] : null,
-            // 'tempfile_name'   => $is_upload ? $_FILES['post']['name']['file'] : null,
-            // 'is_upload'       => $is_upload,
+            'tempfile_path'   => $tmpfile_path,
+            'tempfile_name'   => $tmpfile_name,
+            'is_import'       => false,
         ));
 
         $this->post = Post::create($post_params);

--- a/app/controllers/PostController.php
+++ b/app/controllers/PostController.php
@@ -653,15 +653,19 @@ class PostController extends ApplicationController
         $p = Post::find($this->params()->id);
         $score = (int)$this->params()->score;
 
-        if (!current_user()->is_mod_or_higher() && ($score < 0 || $score > 3)) {
-            $this->respond_to_error("Invalid score", array("#show", 'id' => $this->params()->id, 'tag_title' => $p->tag_title(), 'status' => 424));
-            return;
-        }
+        // the score will be clamped to [0,3] anyway so no need for this...
+        //if (!current_user()->is_mod_or_higher() && ($score < 0 || $score > 3)) {
+        //    $this->respond_to_error("Invalid score", array("#show", 'id' => $this->params()->id, 'tag_title' => $p->tag_title(), 'status' => 424));
+        //    return;
+        //}
 
         $vote_successful = $p->vote($score, current_user());
 
-        $api_data = Post::batch_api_data(array($p));
-        $api_data['voted_by'] = $p->voted_by();
+        // there is no reason to return all of this data; the client likely doesn't care
+        // and can use /post/index or /post/show if they do actually want the post data
+        //$api_data = Post::batch_api_data(array($p));
+        //$api_data['voted_by'] = $p->voted_by();
+        $api_data = ['success' => (bool)$vote_successful];
 
         if ($vote_successful)
             $this->respond_to_success("Vote saved", array("#show", 'id' => $this->params()->id, 'tag_title' => $p->tag_title()), array('api' => $api_data));

--- a/app/controllers/PostController.php
+++ b/app/controllers/PostController.php
@@ -176,6 +176,11 @@ class PostController extends ApplicationController
         $post = $this->params()->post;
         Post::filter_api_changes($post);
 
+        if (isset($post['rating']) && $post['rating'] != $this->post->rating && $this->post->is_rating_locked && !current_user()->is_privileged_or_higher()) {
+            $this->respond_to_error('Rating Locked', ['#show', 'id' => $this->params()->id], ['status' => 400]);
+            return;
+        }
+
         $post['updater_user_id'] = current_user()->id;
         $post['updater_ip_addr'] = $this->request()->remoteIp();
 

--- a/app/controllers/PostController.php
+++ b/app/controllers/PostController.php
@@ -529,13 +529,17 @@ class PostController extends ApplicationController
             $this->include_tag_reverse_aliases = true;
             $this->set_title(str_replace('_', ' ', $this->post->title_tags()));
             $this->respondTo([
-                'html'
+                'html',
+                'xml',
+                'json' => function() { $this->render(['json' => $this->post->api_attributes()]); }
             ]);
         } catch (Rails\ActiveRecord\Exception\RecordNotFoundException $e) {
+            $pid = $this->params()->id;
+            $apierr = ['success' => false, 'reason' => "post with id {$pid} not found"];
             $this->respondTo([
-                'html' => function() {
-                    $this->render(array('action' => 'show_empty', 'status' => 404));
-                }
+                'html' => function() { $this->render(['action' => 'show_empty', 'status' => 404]); },
+                'json' => function() use ($apierr) { $this->render(['json' => $apierr, 'status' => 404]); },
+                'xml' => function() use ($apierr) { $this->render(['xml' => $apierr, 'root' => 'response', 'status' => 404]); },
             ]);
         }
     }

--- a/app/controllers/TagController.php
+++ b/app/controllers/TagController.php
@@ -114,11 +114,11 @@ class TagController extends ApplicationController
                     // $this->response()->headers()->add("X-Accel-Redirect", Rails::publicPath() . "/tags.xml");
                     // $this->render(array('nothing' => true));
                 // } else {
-                    $this->render(array('xml' => $query->limit($limit)->take(), 'root' => "tags"));
+                    $this->render(array('xml' => $query->paginate($this->page_number(), $limit), 'root' => "tags"));
                 // }
             },
             'json' => function () use ($order, $limit, $query) {
-                $tags = $query->limit($limit)->take();
+                $tags = $query->paginate($this->page_number(), $limit);
                 $this->render(array('json' => $tags));
             }
         ));

--- a/app/controllers/TagController.php
+++ b/app/controllers/TagController.php
@@ -214,22 +214,7 @@ class TagController extends ApplicationController
         }
 
         $this->respondTo([
-            // fmt.xml do
-                // # We basically have to do this by hand.
-                // builder = Builder::XmlMarkup.new('indent' => 2)
-                // builder.instruct!
-                // xml = builder.tag!("tags") do
-                    // $this->tags.each do |parent, related|
-                        // builder.tag!("tag", 'name' => parent) do
-                            // related.each do |tag, count|
-                                // builder.tag!("tag", 'name' => tag, 'count' => count)
-                            // end
-                        // end
-                    // end
-                // end
-
-                // $this->render(array('xml' => xml)
-            // end
+            'xml', // => execute view tag/related.xml.php
             'json' => function() { $this->render(['json' => json_encode($this->tags)]); }
         ]);
     }

--- a/app/controllers/UserController.php
+++ b/app/controllers/UserController.php
@@ -244,7 +244,12 @@ class UserController extends ApplicationController
             return;
         }
 
-        if (current_user()->updateAttributes($this->params()->user)) {
+        $user = $this->params()->user;
+        unset($user['name']);
+        $dname = trim($user['download_name']);
+        $user['download_name'] = strlen($dname) == 0 ? null : $dname;
+
+        if (current_user()->updateAttributes($user)) {
             $this->respond_to_success("Account settings saved", '#edit');
         } else {
             if ($this->params()->render and $this->params()->render['view']) {

--- a/app/controllers/WikiController.php
+++ b/app/controllers/WikiController.php
@@ -178,7 +178,11 @@ class WikiController extends ApplicationController
         
         $this->wiki_pages = WikiPageVersion::where('wiki_page_id = ?', $wiki_id)->order('version DESC')->take();
 
-        $this->respond_to_list("wiki_pages");
+        $this->respondTo([
+            'html',
+            'xml',
+            'json' => function() { $this->render(['json' => $this->wiki_pages->toJson()]); },
+        ]);
     }
 
     public function diff()

--- a/app/models/Note.php
+++ b/app/models/Note.php
@@ -110,4 +110,22 @@ class Note extends Rails\ActiveRecord\Base
     {
         return $relation->order("updated_at DESC");
     }
+
+
+    public function asJson()
+    {
+        return [
+            'id'            => $this->id,
+            'created_at'    => $this->created_at,
+            'updated_at'    => $this->updated_at,
+            'user_id'       => $this->user_id,
+            'x'             => $this->x,
+            'y'             => $this->y,
+            'width'         => $this->width,
+            'height'        => $this->height,
+            'version'       => $this->version,
+            'post_id'       => $this->post_id,
+            'body'          => $this->body,
+        ];
+    }
 }

--- a/app/models/NoteVersion.php
+++ b/app/models/NoteVersion.php
@@ -6,9 +6,9 @@ class NoteVersion extends Rails\ActiveRecord\Base
         // {:created_at => created_at, :updated_at => updated_at, :creator_id => user_id, :x => x, :y => y, :width => width, :height => height, :is_active => is_active, :post_id => post_id, :body => body, :version => version}.to_xml(options.reverse_merge(:root => "note_version"))
     }
 
-    public function asJson(array $args = array())
+    public function asJson()
     {
-        return json_encode(array(
+        return [
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
             'creator_id' => $this->user_id,
@@ -20,7 +20,7 @@ class NoteVersion extends Rails\ActiveRecord\Base
             'post_id'   => $this->post_id,
             'body'      => $this->body,
             'version'   => $this->version
-        ));
+        ];
     }
 
     public function author()

--- a/app/models/Post/ApiMethods.php
+++ b/app/models/Post/ApiMethods.php
@@ -38,10 +38,11 @@ trait PostApiMethods
             'width' => (int)$this->width,
             'height' => (int)$this->height,
             'is_held' => (bool)$this->is_held,
-            //'frames_pending_string' => '', //$this->frames_pending,
-            //'frames_pending' => [], //$this->frames_api_data($this->frames_pending),
-            //'frames_string' => '', //$this->frames,
-            //'frames' => [] //frames_api_data(frames)
+            // these fields are required for post browser
+            'frames_pending_string' => '', //$this->frames_pending,
+            'frames_pending' => [], //$this->frames_api_data($this->frames_pending),
+            'frames_string' => '', //$this->frames,
+            'frames' => [] //frames_api_data(frames)
         ];
         
         if ($this->status == "deleted") {

--- a/app/models/Post/ApiMethods.php
+++ b/app/models/Post/ApiMethods.php
@@ -38,10 +38,10 @@ trait PostApiMethods
             'width' => (int)$this->width,
             'height' => (int)$this->height,
             'is_held' => (bool)$this->is_held,
-            'frames_pending_string' => '', //$this->frames_pending,
-            'frames_pending' => [], //$this->frames_api_data($this->frames_pending),
-            'frames_string' => '', //$this->frames,
-            'frames' => [] //frames_api_data(frames)
+            //'frames_pending_string' => '', //$this->frames_pending,
+            //'frames_pending' => [], //$this->frames_api_data($this->frames_pending),
+            //'frames_string' => '', //$this->frames,
+            //'frames' => [] //frames_api_data(frames)
         ];
         
         if ($this->status == "deleted") {

--- a/app/models/Post/ApiMethods.php
+++ b/app/models/Post/ApiMethods.php
@@ -87,6 +87,37 @@ trait PostApiMethods
     {
         unset($params['frames']);
         unset($params['frames_warehoused']);
+        unset($params['id']);
+        unset($params['user_id']);
+        unset($params['file_size']);
+        unset($params['md5']);
+        unset($params['last_commented_at']);
+        unset($params['last_noted_at']);
+        unset($params['cached_tags']);
+        unset($params['width']);
+        unset($params['height']);
+        unset($params['created_at']);
+        unset($params['preview_width']);
+        unset($params['preview_height']);
+        unset($params['actual_preview_width']);
+        unset($params['actual_preview_height']);
+        unset($params['score']);
+        unset($params['has_children']);
+        unset($params['status']);
+        unset($params['sample_Width']);
+        unset($params['sample_height']);
+        unset($params['sample_size']);
+        unset($params['index_timestamp']);
+        unset($params['jpeg_width']);
+        unset($params['jpeg_height']);
+        unset($params['jpeg_size']);
+        unset($params['approver_id']);
+
+        if (!current_user()->is_privileged_or_higher()) {
+            unset($params['is_note_locked']);
+            unset($params['is_rating_locked']);
+            unset($params['is_shown_in_index']);
+        }
     }
 
     /**

--- a/app/models/Post/FileMethods.php
+++ b/app/models/Post/FileMethods.php
@@ -143,6 +143,29 @@ trait PostFileMethods
         
         return $name;
     }
+
+
+    public function download_name()
+    {
+        $name = current_user()->download_name;
+
+        if (!$name) {
+            $name = CONFIG()->use_pretty_image_urls
+                ? $this->pretty_file_name() . '.' . $this->file_ext
+                : $this->file_name();
+        } else {
+            $tags = !strpos($name, '{TAGS}') ? ''
+                : str_replace(['/', '?'], ['_', ''], Tag::compact_tags($this->cached_tags, 150));
+
+            $name = str_replace(
+                ['{ID}', '{MD5}', '{WIDTH}', '{HEIGHT}', '{SIZE}', '{TAGS}'],
+                [$this->id, $this->md5, $this->width, $this->height, $this->file_size, $tags],
+                $name) . '.' . $this->file_ext;
+        }
+
+        return $name;
+    }
+
     
     public function file_name()
     {

--- a/app/models/Post/FileMethods.php
+++ b/app/models/Post/FileMethods.php
@@ -475,7 +475,7 @@ trait PostFileMethods
         return $dim;
     }
 
-    public function generate_sample($force_regen = false)
+    public function generate_sample($force_regen = true)
     {
         if ($this->gif() || !$this->image()) return true;
         elseif (!CONFIG()->image_samples) return true;
@@ -531,7 +531,7 @@ trait PostFileMethods
         return true;
     }
     
-    protected function generate_preview($force_regen = false)
+    protected function generate_preview($force_regen = true)
     {
         if (!$this->image() || (!$this->width && !$this->height))
             return true;
@@ -573,7 +573,7 @@ trait PostFileMethods
 
     # If the JPEG version needs to be generated (or regenerated), output it to tempfile_jpeg_path.    On
     # error, return; false; on success or no-op, return; true.
-    protected function generate_jpeg($force_regen = false)
+    protected function generate_jpeg($force_regen = true)
     {
         if ($this->gif() || !$this->image()) return true;
         elseif (!CONFIG()->jpeg_enable) return true;

--- a/app/models/Post/ImageStore/LocalFlat.php
+++ b/app/models/Post/ImageStore/LocalFlat.php
@@ -8,6 +8,8 @@ class Post_ImageStore_LocalFlat extends Post_ImageStore_Base
 
     public function file_url()
     {
+        if (current_user()->download_name)
+            return CONFIG()->url_base . "/image/".$this->_post->md5."/".$this->_post->download_name();
         if (CONFIG()->use_pretty_image_urls)
             return CONFIG()->url_base . "/image/".$this->_post->md5."/".urlencode($this->_post->pretty_file_name()).".".$this->_post->file_ext;
         else

--- a/app/models/Post/ImageStore/LocalHierarchy.php
+++ b/app/models/Post/ImageStore/LocalHierarchy.php
@@ -8,7 +8,9 @@ class Post_ImageStore_LocalHierarchy extends Post_ImageStore_Base
 
     public function file_url()
     {
-        if (CONFIG()->use_pretty_image_urls)
+        if (current_user()->download_name)
+            return CONFIG()->url_base . "/image/".$this->_post->md5."/".$this->_post->download_name();
+        else if (CONFIG()->use_pretty_image_urls)
             return CONFIG()->url_base . "/image/".$this->_post->md5."/".$this->_post->pretty_file_name().".".$this->_post->file_ext;
         else
             return CONFIG()->url_base . "/data/image/".$this->_post->file_name();

--- a/app/models/WikiPageVersion.php
+++ b/app/models/WikiPageVersion.php
@@ -42,6 +42,6 @@ class WikiPageVersion extends Rails\ActiveRecord\Base
 
     public function asJson(array $args = array())
     {
-        return array('id' => $this->id, 'created_at' => $this->created_at, 'updated_at' => $this->updated_at, 'title' => $this->title, 'body' => $this->body, 'updater_id' => $this->user_id, 'locked' => $this->is_locked, 'version' => $this->version, 'post_id' => $this->post_id);
+        return array('id' => $this->id, 'created_at' => $this->created_at, 'updated_at' => $this->updated_at, 'title' => $this->title, 'body' => $this->body, 'updater_id' => $this->user_id, 'locked' => $this->is_locked, 'version' => $this->version);
     }
 }

--- a/app/views/artist/destroy.php
+++ b/app/views/artist/destroy.php
@@ -3,5 +3,5 @@
 
 <?= $this->formTag([], ['level' => 'privileged'], function(){ ?>
   <button type="submit" name="commit" value="Yes"><?= $this->t('buttons._yes') ?></button>
-  <button type="submit"><?= $this->t('buttons._no') ?></button>
+  <button type="submit" name="commit" value="No"><?= $this->t('buttons._no') ?></button>
 <?php }) ?>

--- a/app/views/artist/index.xml.php
+++ b/app/views/artist/index.xml.php
@@ -1,0 +1,20 @@
+<?php
+$dom = new DOMDocument('1.0', 'UTF-8');
+$root = $dom->appendChild($dom->createElement('artists'));
+$root->setAttribute('count', $this->artists->totalRows());
+$root->setAttribute('offset', ($this->artists->currentPage() - 1) * $this->artists->perPage());
+
+foreach ($this->artists as $artist)
+{
+    $ael = $root->appendChild($dom->createElement('artist'));
+    $attrs = $artist->api_attributes();
+
+    $ael->setAttribute('id', strval($attrs['id']));
+    $ael->setAttribute('name', strval($attrs['name']));
+    $ael->setAttribute('alias_id', strval($attrs['alias_id']));
+    $ael->setAttribute('group_id', strval($attrs['group_id']));
+    $ael->setAttribute('urls', implode(' ', $attrs['urls']));
+
+}
+
+echo($dom->saveXML());

--- a/app/views/comment/index.xml.php
+++ b/app/views/comment/index.xml.php
@@ -1,0 +1,19 @@
+<?php
+$dom = new DOMDocument('1.0', 'UTF-8');
+$root = $dom->appendChild($dom->createElement('comments'));
+$root->setAttribute('count', $this->comments->totalRows());
+$root->setAttribute('offset', ($this->comments->currentPage() - 1) * $this->comments->perPage());
+
+foreach ($this->comments as $comment)
+{
+    $el = $root->appendChild($dom->createElement('comment'));
+
+    foreach ($comment->api_attributes() as $key => $value)
+    {
+        if (!isset($value)) { continue; }
+        if (is_bool($value)) { $value = $value ? 'true' : 'false'; }
+        $el->setAttribute($key, strval($value));
+    }
+}
+
+echo($dom->saveXML());

--- a/app/views/comment/show.xml.php
+++ b/app/views/comment/show.xml.php
@@ -1,0 +1,13 @@
+<?php
+$dom = new DOMDocument('1.0', 'UTF-8');
+$root = $dom->appendChild($dom->createElement('comment'));
+
+foreach ($this->comment->api_attributes() as $key => $value)
+{
+    if (!isset($value)) { continue; }
+    if (is_bool($value)) { $value = $value ? 'true' : 'false'; }
+    $root->setAttribute($key, strval($value));
+}
+
+
+echo($dom->saveXML());

--- a/app/views/note/history.xml.php
+++ b/app/views/note/history.xml.php
@@ -1,0 +1,17 @@
+<?php
+$dom = new DOMDocument('1.0', 'UTF-8');
+$root = $dom->appendChild($dom->createElement('notes'));
+
+foreach ($this->notes as $note)
+{
+    $el = $root->appendChild($dom->createElement('note'));
+
+    foreach ($note->asJson() as $key => $value)
+    {
+        if (!isset($value) || is_array($value)) { continue; }
+        if (is_bool($value)) { $value = $value ? 'true' : 'false'; }
+        $el->setAttribute($key, strval($value));
+    }
+}
+
+echo($dom->saveXML());

--- a/app/views/note/index.xml.php
+++ b/app/views/note/index.xml.php
@@ -1,0 +1,17 @@
+<?php
+$dom = new DOMDocument('1.0', 'UTF-8');
+$root = $dom->appendChild($dom->createElement('notes'));
+
+foreach ($this->notes as $note)
+{
+    $el = $root->appendChild($dom->createElement('note'));
+
+    foreach ($note->asJson() as $key => $value)
+    {
+        if (!isset($value) || is_array($value)) { continue; }
+        if (is_bool($value)) { $value = $value ? 'true' : 'false'; }
+        $el->setAttribute($key, strval($value));
+    }
+}
+
+echo($dom->saveXML());

--- a/app/views/note/search.xml.php
+++ b/app/views/note/search.xml.php
@@ -1,0 +1,17 @@
+<?php
+$dom = new DOMDocument('1.0', 'UTF-8');
+$root = $dom->appendChild($dom->createElement('notes'));
+
+foreach ($this->notes as $note)
+{
+    $el = $root->appendChild($dom->createElement('note'));
+
+    foreach ($note->asJson() as $key => $value)
+    {
+        if (!isset($value) || is_array($value)) { continue; }
+        if (is_bool($value)) { $value = $value ? 'true' : 'false'; }
+        $el->setAttribute($key, strval($value));
+    }
+}
+
+echo($dom->saveXML());

--- a/app/views/post/index.xml.php
+++ b/app/views/post/index.xml.php
@@ -10,7 +10,7 @@ foreach ($this->posts as $post)
 
     foreach ($post->api_attributes() as $key => $value)
     {
-        if (!isset($value) || strpos($key, 'frame') === 0) { continue; }
+        if (!isset($value)) { continue; }
         if (is_bool($value)) { $value = $value ? 'true' : 'false'; }
         $pel->setAttribute($key, strval($value));
     }

--- a/app/views/post/index.xml.php
+++ b/app/views/post/index.xml.php
@@ -10,8 +10,9 @@ foreach ($this->posts as $post)
 
     foreach ($post->api_attributes() as $key => $value)
     {
-        if (!$value) { continue; }
-        $pel->setAttribute($key, $value);
+        if (!isset($value) || strpos($key, 'frame') === 0) { continue; }
+        if (is_bool($value)) { $value = $value ? 'true' : 'false'; }
+        $pel->setAttribute($key, strval($value));
     }
 }
 

--- a/app/views/post/index.xml.php
+++ b/app/views/post/index.xml.php
@@ -10,7 +10,7 @@ foreach ($this->posts as $post)
 
     foreach ($post->api_attributes() as $key => $value)
     {
-        if (!isset($value)) { continue; }
+        if (!isset($value) || is_array($value)) { continue; }
         if (is_bool($value)) { $value = $value ? 'true' : 'false'; }
         $pel->setAttribute($key, strval($value));
     }

--- a/app/views/post/index.xml.php
+++ b/app/views/post/index.xml.php
@@ -1,10 +1,18 @@
 <?php
-echo '<?xml version="1.0" encoding="UTF-8"?>' . "\n";
-echo $this->contentTag('posts', function() {
-    // Make it look pretty.
-    echo "\n";
-    
-    foreach ($this->posts as $post) {
-        echo '  ' . $this->tag('post', $post->api_attributes(), false, true) . "\n";
+$dom = new DOMDocument('1.0', 'UTF-8');
+$root = $dom->appendChild($dom->createElement('posts'));
+$root->setAttribute('count', $this->posts->totalRows());
+$root->setAttribute('offset', ($this->posts->currentPage() - 1) * $this->posts->perPage());
+
+foreach ($this->posts as $post)
+{
+    $pel = $root->appendChild($dom->createElement('post'));
+
+    foreach ($post->api_attributes() as $key => $value)
+    {
+        if (!$value) { continue; }
+        $pel->setAttribute($key, $value);
     }
-}, ['count' => $this->posts->totalRows(), 'offset' => ($this->posts->currentPage() - 1) * $this->posts->perPage()]);
+}
+
+echo($dom->saveXML());

--- a/app/views/post/show.xml.php
+++ b/app/views/post/show.xml.php
@@ -4,7 +4,7 @@ $root = $dom->appendChild($dom->createElement('post'));
 
 foreach ($this->post->api_attributes() as $key => $value)
 {
-    if (!isset($value)) { continue; }
+    if (!isset($value) || is_array($value)) { continue; }
     if (is_bool($value)) { $value = $value ? 'true' : 'false'; }
     $root->setAttribute($key, strval($value));
 }

--- a/app/views/post/show.xml.php
+++ b/app/views/post/show.xml.php
@@ -1,0 +1,12 @@
+<?php
+$dom = new DOMDocument('1.0', 'UTF-8');
+$root = $dom->appendChild($dom->createElement('post'));
+
+foreach ($this->post->api_attributes() as $key => $value)
+{
+    if (!isset($value)) { continue; }
+    if (is_bool($value)) { $value = $value ? 'true' : 'false'; }
+    $root->setAttribute($key, strval($value));
+}
+
+echo($dom->saveXML());

--- a/app/views/post/show_partials/_options_panel.php
+++ b/app/views/post/show_partials/_options_panel.php
@@ -15,27 +15,17 @@
           ?>
       </li>
       <?php endif ?>
-      <li><?php if (array_key_exists("dakimakura", $this->post->tags()) && !current_user()->is_contributor_or_higher()) :
-                      $file_sample = $this->post->get_file_sample(current_user());
-                      echo $this->linkTo(($this->post->has_sample() ? $this->t('.download.larger') : $this->t('.download.normal')) . ' (' . $this->numberToHumanSize($file_sample['size']) . ' ' . strtoupper($file_sample['ext']) . ')', $this->h($file_sample['url']), array(
-                      'class' => $this->post->has_sample() ? "original-file-changed":"original-file-unchanged",
-                      'id' => 'highres'));
-              else:
-                      echo $this->linkTo(($this->post->has_sample() ? $this->t('.download.larger') : $this->t('.download.image')) . ' (' . $this->numberToHumanSize($file_jpeg['size']) . ' ' . strtoupper($file_jpeg['ext']) . ')', $this->h($file_jpeg['url']), array(
-                      'class' => ($this->post->has_sample() ? "original-file-changed":"original-file-unchanged"),
-                      'id' => 'highres'));
-              endif
-          ?>
-      </li>
-      <?php if ($this->post->has_jpeg()) : ?>
-        <?php $file_image = $this->post->get_file_image() ?>
-        <?php # If we have a JPEG, the above link was the JPEG.  Link to the PNG here. ?>
-        <li><?= $this->linkTo($this->t('.download.normal').' '.strtoupper($file_image['ext']).' ('.$this->numberToHumanSize($file_image['size']).')', $file_image['url'], array(
-                        'class' => 'original-file-unchanged',
-                        'id' => 'png'));
-                ?>
-        </li>
-      <?php endif ?>
+
+    <?php
+        $file_image = $this->post->get_file_image();
+        $file_ext = strtoupper($file_image['ext']);
+        $file_size = $this->numberToHumanSize($file_image['size']);
+        $file_attrs = ['class' => 'original-file-unchanged', 'id' => 'png'];
+        if (current_user()->download_mode == 1) { $file_attrs['target'] = '_blank'; }
+        else if (current_user()->download_mode == 2) { $file_attrs['download'] = $this->post->download_name(); }
+        echo($this->linkTo($this->t('.download.larger') . " ({$file_size} {$file_ext})", $file_image['url'], $file_attrs));
+    ?>
+
     <?php endif ?>
     <?php if ($this->post->can_user_delete(current_user())) : ?>
     <li><?= $this->linkTo($this->t('.delete'), array('#delete', 'id' => $this->post->id)) ?></li>

--- a/app/views/tag/related.xml.php
+++ b/app/views/tag/related.xml.php
@@ -1,0 +1,18 @@
+<?php
+$dom = new DOMDocument('1.0', 'UTF-8');
+$root = $dom->appendChild($dom->createElement('tags'));
+
+foreach ($this->tags as $parent => $related)
+{
+    $pel = $root->appendChild($dom->createElement('tag'));
+    $pel->setAttribute('name', $parent);
+
+    foreach ($related as $tag)
+    {
+        $rel = $pel->appendChild($dom->createElement('tag'));
+        $rel->setAttribute('name', $tag[0]);
+        $rel->setAttribute('count', $tag[1]);
+    }
+}
+
+echo($dom->saveXML());

--- a/app/views/user/edit.php
+++ b/app/views/user/edit.php
@@ -52,6 +52,25 @@
         </tr>
         <tr>
           <th>
+            <label class="block" for="user_download_mode">Download Mode</label>
+            <p>Behavior of download link.</p>
+          </th>
+          <td>
+            <?= $this->select("user", "download_mode",
+                ['Open Image' => '0', 'Open New Tab' => '1', 'Trigger Download' => '2']) ?>
+          </td>
+        </tr>
+        <tr>
+          <th>
+            <label class="block" for="user_download_name">Download File Name</label>
+            <p>Format of download file name (blank for default).</p>
+          </th>
+          <td>
+            <?= $this->textField("user", "download_name", ['size' => 40]) ?>
+          </td>
+        </tr>
+        <tr>
+          <th>
             <label class="block" for="user_always_resize_images"><?= $this->t('user11') ?></label>
             <p><?= $this->t('user12') ?></p>
           </th>

--- a/app/views/wiki/history.xml.php
+++ b/app/views/wiki/history.xml.php
@@ -1,0 +1,18 @@
+<?php
+$dom = new DOMDocument('1.0', 'UTF-8');
+$root = $dom->appendChild($dom->createElement('wiki_pages'));
+
+foreach ($this->wiki_pages as $page)
+{
+    $pel = $root->appendChild($dom->createElement('page'));
+    $pel->setAttribute('id',            $page->id           );
+    $pel->setAttribute('created_at',    $page->created_at   );
+    $pel->setAttribute('updated_at',    $page->updated_at   );
+    $pel->setAttribute('title',         $page->title        );
+    $pel->setAttribute('body',          $page->body         );
+    $pel->setAttribute('updater_id',    $page->user_id      );
+    $pel->setAttribute('locked',        $page->is_locked    );
+    $pel->setAttribute('version',       $page->version      );
+}
+
+echo($dom->saveXML());

--- a/config/routes.php
+++ b/config/routes.php
@@ -145,7 +145,7 @@ MyImouto\Application::routes()->draw(function() {
     $this->match('post/popular_by_week', ['via' => ['head', 'get', 'post']]);
     $this->match('post/popular_recent', ['via' => ['head', 'get', 'post']]);
     $this->match('post/random(/:id)', 'post#random', ['via' => ['head', 'get', 'post']]);
-    $this->match('post/show(/:id)(/*tag_title)', 'post#show', ['constraints' => ['id' => '/^\d+$/'], 'format' => false, 'via' => ['head', 'get', 'post']]);
+    $this->match('post/show(.:format)(/:id)(/*tag_title)', 'post#show', ['constraints' => ['id' => '/^\d+$/'], 'via' => ['head', 'get', 'post']]);
     $this->match('post/similar(/:id)', 'post#similar', ['via' => ['head', 'get', 'post']]);
     $this->match('post/undelete(/:id)', 'post#undelete', ['via' => ['head', 'get', 'post']]);
     $this->match('post/update_batch', ['via' => ['head', 'get', 'post']]);

--- a/db/migrate/20211212000001_add_download_settings.php
+++ b/db/migrate/20211212000001_add_download_settings.php
@@ -1,0 +1,10 @@
+<?php
+class AddDownloadSettings extends Rails\ActiveRecord\Migration\Base
+{
+    public function up()
+    {
+        $sql = Rails\ActiveRecord\ActiveRecord::connection();
+        $sql->executeSql("ALTER TABLE `users` ADD COLUMN `download_mode` tinyint(1) NOT NULL DEFAULT 0");
+        $sql->executeSql("ALTER TABLE `users` ADD COLUMN `download_name` varchar(255) DEFAULT NULL");
+    }
+}

--- a/db/table_schema/production/users.php
+++ b/db/table_schema/production/users.php
@@ -152,6 +152,8 @@ return array (
       'type' => 'tinyint(1)',
       'default' => '0',
     ),
+    'download_mode' => [ 'type' => 'tinyint(1)', 'default' => 0 ],
+    'download_name' => [ 'type' => 'varchar(255)', 'default' => 0 ],
   ),
   1 => 
   array (


### PR DESCRIPTION
I added a feature to allow users to customize the file name and behavior of the download link.

These enhancements should satisfy the requests in forum post 5337 and 4909

First this adds a "Download Mode" option to account settings with the following choices:

- Open Image (just opens the image; the current behavior)
- Open New Tab (opens the image in a new tab instead of current tab)
- Trigger Download (will trigger a file download instead of opening the image)

Second this adds a "Download File Name" option. This allows the user to specify a pattern for the file name. (URL rewriting is required, but "pretty names" also requires this). The user can specify some placeholders that will be replaced with information about the image. Other text will be passed through to the file name. The supported placeholders are:

- {ID} will be replaced with the post id
- {MD5} will be replaced with the MD5 hash
- {WIDTH} will be replaced with the image width
- {HEIGHT} will be replaced with the image height
- {SIZE} will be replaced with the file size in bytes
- {TAGS} will be replaced with the pretty name tags

So for example, setting this to `{ID} - {MD5} ({WIDTH}x{HEIGHT})` would give a file name like `12345 - 2a0c10d456b269ff7b8851dddc3ec41c (1024x768).png`.

Before changing anything else, you will need to get the database migration and run it `php config/boot.php db:migrate` which will add two columns to the user table to hold these new settings.

Careful merging changes with the _options_panel.php view. I think you have made changes to this view for displaying avatars which I don't have.

This PR also includes all of the API improvements up to this point.