### PR TITLE
Saved Search

### DIFF
--- a/app/models/Post/CountMethods.php
+++ b/app/models/Post/CountMethods.php
@@ -6,9 +6,9 @@ trait PostCountMethods
         # A small sanitation
         $tags = preg_replace('/ +/', ' ', trim($tags));
         $cache_version = (int)Rails::cache()->read('$cache_version');
-        $key = ['post_count' => hash('sha256', $tags, false), 'v' => $cache_version];
+        $key = ['post_count' => hash('fnv164', $tags, false), 'v' => $cache_version];
 
-        $count = (int)Rails::cache()->fetch($key, function() use ($tags) {
+        $count = (int)Rails::cache()->fetch($key, ['expires_in' => '1 day'], function() use ($tags) {
             list($sql, $params) = Post::generate_sql($tags, ['count' => true]);
             array_unshift($params, $sql);
             return Post::countBySql($params);

--- a/app/models/Tag.php
+++ b/app/models/Tag.php
@@ -499,7 +499,7 @@ class Tag extends Rails\ActiveRecord\Base
         
         !is_array($tags) && $tags = array($tags);
         
-        return Rails::cache()->fetch(['category' => 'reltags', 'tags' => hash('sha256', implode(',', $tags), false)], ['expires_in' => '1 hour'], function() use ($tags) {
+        return Rails::cache()->fetch(['category' => 'reltags', 'tags' => hash('fnv164', implode(',', $tags), false)], ['expires_in' => '1 hour'], function() use ($tags) {
             $from = array("posts_tags pt0");
             $cond = array("pt0.post_id = pt1.post_id");
             $sql = "SELECT ";

--- a/app/models/Tag/CacheMethods.php
+++ b/app/models/Tag/CacheMethods.php
@@ -8,7 +8,7 @@ trait CacheMethods
 {
     protected function update_cache()
     {
-        Rails::cache()->write(['tag_type' => $this->name], self::type_name_from_value($this->tag_type));
+        Rails::cache()->write(['tag_type' => $this->name], self::type_name_from_value($this->tag_type), ['expires_in' => '1 day']);
         
         # Expire the tag cache if a tag's type changes.
         if ($this->tag_type != $this->tagTypeWas()) {

--- a/app/models/TagSubscription.php
+++ b/app/models/TagSubscription.php
@@ -50,16 +50,7 @@ class TagSubscription extends Rails\ActiveRecord\Base
 
     static public function find_post_ids($user_id, $name = null, $limit = null)
     {
-        if (!$limit) { $limit = CONFIG()->tag_subscription_post_limit; }
-
-        $sub = self::select('tag_query')->where(['user_id' => $user_id, 'name' => $name])->first();
-        $tags = $sub ? $sub->tag_query : '';
-
-        $q = Tag::parse_query($tags);
-        list ($sql, $params) = Post::generate_sql($q, ['original_query' => $tags, 'order' => "p.id DESC", 'limit' => $limit]);
-
-        $ids = [];
-        $posts = Post::findBySql($sql, $params);
+        $posts = self::find_posts($user_id, $name, $limit);
         foreach ($posts as $post) { $ids[] = $post->id; }
         return $ids;
     }

--- a/app/models/TagSubscription.php
+++ b/app/models/TagSubscription.php
@@ -50,32 +50,32 @@ class TagSubscription extends Rails\ActiveRecord\Base
 
     static public function find_post_ids($user_id, $name = null, $limit = null)
     {
-        if (!$limit) {
-            $limit = CONFIG()->tag_subscription_post_limit;
-        }
+        if (!$limit) { $limit = CONFIG()->tag_subscription_post_limit; }
 
-        $post_ids = self::select('cached_post_ids')->where(['user_id' => $user_id]);
-        if ($name) {
-            $post_ids->where('name LIKE ?', $name . '%');
-        }
-        $post_ids = $post_ids->take();
+        $sub = self::select('tag_query')->where(['user_id' => $user_id, 'name' => $name])->first();
+        $tags = $sub ? $sub->tag_query : '';
 
-        $parsed_ids = [];
-        foreach ($post_ids as $subs) {
-            $ids = explode(',', $subs->cached_post_ids);
-            foreach ($ids as &$id) {
-                $id = (int)$id;
-            }
-            $parsed_ids = array_merge($parsed_ids, $ids);
-        }
-        sort($parsed_ids);
+        $q = Tag::parse_query($tags);
+        list ($sql, $params) = Post::generate_sql($q, ['original_query' => $tags, 'order' => "p.id DESC", 'limit' => $limit]);
 
-        return array_slice(array_reverse(array_unique($parsed_ids)), 0, $limit);
+        $ids = [];
+        $posts = Post::findBySql($sql, $params);
+        foreach ($posts as $post) { $ids[] = $post->id; }
+        return $ids;
     }
 
     static public function find_posts($user_id, $name = null, $limit = null)
     {
-        return Post::available()->where('id IN (?)', self::find_post_ids($user_id, $name, $limit))->order('id DESC')->take();
+        if (!$limit) { $limit = CONFIG()->tag_subscription_post_limit; }
+
+        $sub = self::select('tag_query')->where(['user_id' => $user_id, 'name' => $name])->first();
+        $tags = $sub ? $sub->tag_query : '';
+
+        $q = Tag::parse_query($tags);
+        list ($sql, $params) = Post::generate_sql($q, ['original_query' => $tags, 'order' => "p.id DESC", 'limit' => $limit]);
+
+        $ids = [];
+        return Post::findBySql($sql, $params);
     }
 
     static public function process_all()

--- a/app/models/TagSubscription.php
+++ b/app/models/TagSubscription.php
@@ -65,7 +65,6 @@ class TagSubscription extends Rails\ActiveRecord\Base
         $q = Tag::parse_query($tags);
         list ($sql, $params) = Post::generate_sql($q, ['original_query' => $tags, 'order' => "p.id DESC", 'limit' => $limit]);
 
-        $ids = [];
         return Post::findBySql($sql, $params);
     }
 

--- a/app/models/User.php
+++ b/app/models/User.php
@@ -187,7 +187,7 @@ class User extends Rails\ActiveRecord\Base
 
     static public function find_name($user_id)
     {
-        return Rails::cache()->fetch('user_name:' . $user_id, function() use ($user_id) {
+        return Rails::cache()->fetch('user_name:' . $user_id, ['expires_in' => '1 day'], function() use ($user_id) {
             try {
                 return self::find($user_id)->name;
             } catch (Rails\ActiveRecord\Exception\RecordNotFoundException $e) {
@@ -213,7 +213,7 @@ class User extends Rails\ActiveRecord\Base
 
     protected function update_cached_name()
     {
-        Rails::cache()->write("user_name:".$this->id, $this->name);
+        Rails::cache()->write("user_name:".$this->id, $this->name, ['expires_in' => '1 day']);
     }
     # }
 
@@ -388,7 +388,7 @@ class User extends Rails\ActiveRecord\Base
         $version = (int)Rails::cache()->read('$cache_version');
         $key = 'held-post-count/v=' . $version . '/u=' . $this->id;
         
-        return Rails::cache()->fetch($key, function() {
+        return Rails::cache()->fetch($key, ['expires_in' => '1 day'], function() {
             return Post::where(['user_id' => $this->id, 'is_held' => true])->where('status <> ?', 'deleted')->count();
         });
     }

--- a/config/application.php
+++ b/config/application.php
@@ -29,5 +29,8 @@ class Application extends \Rails\Application\Base
         $config->plugins = [
             'Rails\WillPaginate'
         ];
+
+        // uncomment below to use APCu with changes to railsphp
+        // $config->cache_store = ['apcu_store', 'MyImouto'];
     }
 }


### PR DESCRIPTION
This is the initial steps to replace subscriptions with saved searches.

This changes it so that the "subscriptions" are simply normal tag searches now, performed on demand. The results of the job task are ignored.

The search operators will work as expected now. If users want the old "any tags" behavior then they will need to put the ~tilde in their subscription tags. Users can also now -exclude tags from their subscriptions.

If this works well, then next I will remove the update subscriptions job task and investigate allowing users to have many more subscriptions. Showing the subscriptions on the profile page should still be limited since a search must be performed to display that but there shouldn't really be any reason to limit the number of hidden subscriptions. Also, the number of posts in subscription searches is still limited to the tag_subscription_post_limit setting due to the way the SQL queries work. I can see later about changing the SQL so that it is possible to get all of the posts.

By the way, can you post the changes you made to get html videos to work and to display user avatars on posts?