### PR TITLE
Fix GH-19

### DIFF
--- a/app/helpers/PostHelper.php
+++ b/app/helpers/PostHelper.php
@@ -63,7 +63,10 @@ class PostHelper extends Rails\ActionView\Helper
         $image = '<img src="'.$post->preview_url().'" style="margin-left: '.$crop_left*(-1).'px;" alt="'.$image_title.'" class="'.$image_class.'" title="'.$image_title.'" '.$image_id.' width="'.$width.'" height="'.$height.'">';
         if ($is_post) {
             $plid = '<span class="plid">#pl http://'.CONFIG()->server_host.'/post/show/'.$post->id.'</span>';
-            $target_url = '/post/show/' . $post->id . '/' . $post->tag_title() . $options['url_params'];
+            $target_url = "/post/show/" . $post->id;
+            if (CONFIG()->use_pretty_image_urls) { $target_url .= '/' . $post->tag_title(); }
+            $ctags = urlencode($this->params()->tags);
+            if ($ctags) { $target_url .= '?tags=' . $ctags; }
         } else {
             $plid = "";
             $target_url = $post->url;

--- a/app/helpers/TagHelper.php
+++ b/app/helpers/TagHelper.php
@@ -96,10 +96,19 @@ class TagHelper extends Rails\ActionView\Helper
             else
                 $html .= '<a href="/wiki/show?title=' . $this->u($name) . '">?</a> ';
             
-            if (current_user()->is_privileged_or_higher()) {
-                $html .= '<a href="/post?tags=' . $this->u($name) . '+' . $this->u($this->params()->tags) . '" class="no-browser-link">+</a> ';
-                $html .= '<a href="/post?tags=-' . $this->u($name) . '+' .$this->u($this->params()->tags) . '" class="no-browser-link">&ndash;</a> ';
-            }
+            // I don't know why this feature should be restricted to privileged or higher...
+            // if (current_user()->is_privileged_or_higher()) {
+                $ptags = $ntags = explode(' ', $this->params()->tags);
+                $included = in_array($name, $ptags);
+                $excluded = in_array("-$name", $ptags);
+                if ($excluded) { $ptags = array_diff($ptags, ["-$name"]); }
+                else if (!$included) { $ptags[] = $name; }
+                if ($included) { $ntags = array_diff($ntags, [$name]); }
+                else if (!$excluded) { $ntags[] = "-$name"; }
+
+                $html .= '<a href="/post?tags=' . $this->u(implode(' ', $ptags)) . '" class="no-browser-link">+</a> ';
+                $html .= '<a href="/post?tags=' . $this->u(implode(' ', $ntags)) . '" class="no-browser-link">&ndash;</a> ';
+            // }
             
             if (!empty($options['with_hover_highlight'])) {
                 $mouseover = ' onmouseover="Post.highlight_posts_with_tag(\'' . $this->escapeJavascript($name) . '\')"';

--- a/app/models/Post/FileMethods.php
+++ b/app/models/Post/FileMethods.php
@@ -149,7 +149,7 @@ trait PostFileMethods
                 ? $this->pretty_file_name() . '.' . $this->file_ext
                 : $this->file_name();
         } else {
-            $tags = !strpos($name, '{TAGS}') ? ''
+            $tags = strpos($name, '{TAGS}') === false ? ''
                 : str_replace(['/', '?'], ['_', ''], Tag::compact_tags($this->cached_tags, 150));
 
             $name = str_replace(


### PR DESCRIPTION
I also changed it so this should work for normal users as well since I don't see any reason why not. If you want only privileged users to be able to use this, as in the original code, then uncomment the lines I commented out.

I suggest setting $use_pretty_image_urls = false; in config.php but it is not strictly necessary.

Also since I added the custom download file names, users can still get pretty download names by using {TAGS} for the file download name in the account settings.