### PR TITLE
add config function to automatically add/remove specific post tags

### DIFF
--- a/app/models/Post/TagMethods.php
+++ b/app/models/Post/TagMethods.php
@@ -190,6 +190,8 @@ trait PostTagMethods
      */
     protected function commit_tags()
     {
+        CONFIG()->on_commit_tags_hook($this);
+
         if ($this->isNewRecord() || !$this->new_tags)
             return;
         

--- a/config/default_config.php
+++ b/config/default_config.php
@@ -553,8 +553,8 @@ abstract class DefaultConfig
         if ($post->file_size >= 10485760) { $include[] = 'huge_filesize'; }
         else { $exclude[] = 'huge_filesize'; }
 
-        $post->new_tags = array_merge($post->new_tags, $include);
         $post->new_tags = array_diff($post->new_tags, $exclude);
+        $post->new_tags = array_merge($post->new_tags, $include);
     }
 
 


### PR DESCRIPTION
It should be easy enough to understand.
Perhaps this will allow you to do away with useless_tags.